### PR TITLE
Fixed a bug of loadFromQIIME2

### DIFF
--- a/R/loadFromQIIME2.R
+++ b/R/loadFromQIIME2.R
@@ -233,9 +233,13 @@ loadFromQIIME2 <- function(featureTableFile,
     sam <- read.table(file = file, header = TRUE, sep = "\t", comment.char = "")
     rownames(sam) <- as.character(sam[, 1])
 
-    # remove row: #q2:types
+    # Find if there is #q2:types row, and store its index
     idx <- which(sam == "#q2:types", arr.ind = TRUE)
-    sam <- sam[-idx[, "row"], ]
+
+    # If the length is over zero, "#q2:types" row was found. Then it is removed.
+    if(!(length(idx)==0)){
+        sam <- sam[-idx[, "row"], ]
+    }
 
     S4Vectors::DataFrame(sam)
 }


### PR DESCRIPTION
Hi!

I found one bug from the code that caused the problem that Chandler had. The problem was that, if there was no row that had "#q2:types" information, there was no value for idx. When there was no value for idx, the whole table was accidentally deleted. 

I tested the code, and now it seems to work with Chandler's data. 