### PR TITLE
Fixed a bug that appears when file doesn't include all data

### DIFF
--- a/R/loadFromMothur.R
+++ b/R/loadFromMothur.R
@@ -149,7 +149,7 @@ loadFromMothur <- function(sharedFile,
                            stringsAsFactors=FALSE, 
                            col.names = c("OTU", "Taxonomy"))
     }
-    # Else the is not either gives an error
+    # Else the file is not either gives an error
     else{
         stop("The input '", taxonomyFile, "' must be provided in the ",
              "`taxonomy` or `cons.taxonomy` format. In addition, it must ",

--- a/R/makeTreeSummarizedExperimentFromBiom.R
+++ b/R/makeTreeSummarizedExperimentFromBiom.R
@@ -54,6 +54,16 @@ makeTreeSummarizedExperimentFromBiom <- function(obj){
     counts <- as(biomformat::biom_data(obj), "matrix")
     sample_data <- biomformat::sample_metadata(obj)
     feature_data <- biomformat::observation_metadata(obj)
+    
+    # If sample_data and feature_data is not included in the file, they are NULL,
+    # which leads to error when object is created. --> NULLs are replaced with empty
+    # data frames.
+    if( is.null(sample_data) ){
+        sample_data <- S4Vectors:::make_zero_col_DataFrame(ncol(counts))
+    }
+    if( is.null(feature_data) ){
+        feature_data <- S4Vectors:::make_zero_col_DataFrame(nrow(counts))
+    }
 
     TreeSummarizedExperiment(assays = list(counts = counts),
                              colData = sample_data,

--- a/R/makeTreeSummarizedExperimentFromBiom.R
+++ b/R/makeTreeSummarizedExperimentFromBiom.R
@@ -1,6 +1,6 @@
 #' Loading a biom file
 #'
-#' For convenciance a few functions are available to convert data from a
+#' For convenience a few functions are available to convert data from a
 #' \sQuote{biom} file or object into a
 #' \code{\link[TreeSummarizedExperiment:TreeSummarizedExperiment-class]{TreeSummarizedExperiment}}
 #'

--- a/R/makeTreeSummarizedExperimentFromBiom.R
+++ b/R/makeTreeSummarizedExperimentFromBiom.R
@@ -55,14 +55,10 @@ makeTreeSummarizedExperimentFromBiom <- function(obj){
     sample_data <- biomformat::sample_metadata(obj)
     feature_data <- biomformat::observation_metadata(obj)
     
-    # If sample_data and feature_data is not included in the file, they are NULL,
-    # which leads to error when object is created. --> NULLs are replaced with empty
-    # data frames.
+    # If sample_data is not included in the file, it's NULL, which leads to error
+    # when object is created. --> NULL is replaced with empty data frame.
     if( is.null(sample_data) ){
         sample_data <- S4Vectors:::make_zero_col_DataFrame(ncol(counts))
-    }
-    if( is.null(feature_data) ){
-        feature_data <- S4Vectors:::make_zero_col_DataFrame(nrow(counts))
     }
 
     TreeSummarizedExperiment(assays = list(counts = counts),


### PR DESCRIPTION
Hi!

I found a bug from `makeTreeSummarizedExperimentFromBiom`. I have a biom-file and I wanted to create `TSE` from it. The problem is that it's not include sample metadata, i.e., `colData`. When `TSE` object is created `NULL` leads to an error. I fixed it so that now it is possible to create `TSE` object if biom-file includes only counts.  

I was wondering if this should be constructed like `loadMothur`, i.e., there could be additional parameters for `rowData` and `colData` files. 

1. User could choose if those files are provided. 
2. First, `rowData` and `colData` are fetched from the `biom-file`.
3. If user has provided additional `rowData` and `colData` files, they replace those ones that was fetched from `biom-file`. 
4. `SE` is created instead of `TSE`.

However, I'm not familiar with biom-format. I don't know if the file should normally include `colData` and `rowData`, or is my file just an exception and additional parameters are not needed. 

-Tuomas
