### PR TITLE
Faith: colnames replaced with vector of numbers that represent samples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 0.99.17
+Version: 0.99.18
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut", "cre"),
              email = "felix.gm.ernst@outlook.com",

--- a/R/estimateDiversity.R
+++ b/R/estimateDiversity.R
@@ -361,9 +361,8 @@ setMethod("estimateFaith", signature = c(x="TreeSummarizedExperiment", tree="mis
 
 .calc_faith <- function(mat, tree, ...){
 
-    # Gets name of the samples
-    samples <- colnames(mat)
-    #taxa <- rownames(mat)
+    # Gets vector where number represent nth sample
+    samples <- c(1:ncol(mat))
 
     # Repeats taxa as many times there are samples, i.e. get all the taxa that are
     # analyzed in each sample.


### PR DESCRIPTION
Hi!

I found a bug from `estimateDiversity`. 

I have data that does not contain `colnames` in assay. Currently Faith is using `colnames` and because of that `samples` are `NULL` --> Faith indices are not calculated. 

However, if `samples` are replaced with just a vector that contains index numbers for samples, `samples` is not `NULL` --> Faith indices are calculated.

`samples `doesn't have any bigger meaning here, so this replacement can be done without errors. However, that error that I got was quite weird and might be hard to resolve for user

-Tuomas
