### PR TITLE
Bugfix, wrong variable name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 0.99.18
+Version: 0.99.19
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut", "cre"),
              email = "felix.gm.ernst@outlook.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 0.99.19
+Version: 0.99.20
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut", "cre"),
              email = "felix.gm.ernst@outlook.com",

--- a/R/calculateDMM.R
+++ b/R/calculateDMM.R
@@ -145,8 +145,8 @@ runDMN <- function(x, name = "DMN", ...){
     if(!is(x,"SummarizedExperiment")){
         stop("'x' must be a SummarizedExperiment")
     }
-    metadata(se)[[name]] <- calculateDMN(x, ...)
-    se
+    metadata(x)[[name]] <- calculateDMN(x, ...)
+    x
 }
 
 ################################################################################


### PR DESCRIPTION
Hi, 

I found a bug. There is a variable named `se`, but it does not exist --> error. 

And if user has object named `se`, information is stored there instead of input object, so it can cause that kind of problems also.

-Tuomas