### PR TITLE
Added rowTree check to makePhyFromTSE

### DIFF
--- a/R/makephyloseqFromTreeSummarizedExperiment.R
+++ b/R/makephyloseqFromTreeSummarizedExperiment.R
@@ -107,16 +107,17 @@ setMethod("makePhyloseqFromTreeSummarizedExperiment",
         # If rowTree exists, checks if the rowTree match with rownames:
         # tips labels are found from rownames
         if( !is.null(rowTree(x)) && any(!( rowTree(x)$tip) %in% rownames(x)) ){
-            # Tries to prune the tree. If that does not work, gives an error. 
-            x <- tryCatch(
-                {addTaxonomyTree(x)},
-                error = function(cond){
-                    stop("rowTree does not match with rownames. 'x' can not be converted
-                         to a phyloseq object. Check rowTree(x)$tip and rownames(x).",
-                         call. = FALSE)
-                }
-            )
-            warning("rowTree is agglomerated to match rownames.")
+            # Gets node labels
+            node_labs <- rowLinks(x)$nodeLab
+            # Gets the corresponding rownames
+            node_labs_rownames <- rownames(rowLinks(x))
+            # Prunes the tree
+            tree_pruned <- ape::keep.tip(rowTree(x), node_labs)
+            # Replace tip labels with corresponding rownames
+            tree_pruned$tip.label <- node_labs_rownames
+            # Assigns the pruned tree back to TSE object
+            rowTree(x) <- tree_pruned
+            warning("rowTree is pruned to match rownames.")
         }
         
         # Gets otu_table object from the function above this, if tse contains

--- a/R/makephyloseqFromTreeSummarizedExperiment.R
+++ b/R/makephyloseqFromTreeSummarizedExperiment.R
@@ -68,11 +68,9 @@ setMethod("makePhyloseqFromTreeSummarizedExperiment",
 
         # List of arguments
         args = list()
-
         # Gets the abundance data from assay, and converts it to otu_table
         otu_table <- as.matrix(assay(x, abund_values))
         otu_table <- phyloseq::otu_table(otu_table, taxa_are_rows = TRUE)
-
         # Adds to the list
         args[["otu_table"]] <- otu_table
 
@@ -82,24 +80,21 @@ setMethod("makePhyloseqFromTreeSummarizedExperiment",
             # Gets the taxonomic data from rowData, and converts it to tax_table
             tax_table <- as.matrix(rowData(x)[,taxonomyRanks(x)])
             tax_table <- phyloseq::tax_table(tax_table)
-
             # Adds to the list
             args[["tax_table"]] <- tax_table
         }
-
+        
         # If colData includes information
         if(!( length(colData(x)) == 0 || is.null(ncol(colData(x))) )){
             # Gets the feature_data from colData and converts it to sample_data
             sample_data <- as.data.frame(colData(x))
             sample_data <- phyloseq::sample_data(sample_data)
-
             # Adds to the list
             args[["sample_data"]] <- sample_data
         }
-
+        
         # Creates a phyloseq object
         phyloseq <- do.call(phyloseq::phyloseq, args)
-
         return(phyloseq)
     }
 )
@@ -109,7 +104,6 @@ setMethod("makePhyloseqFromTreeSummarizedExperiment",
 setMethod("makePhyloseqFromTreeSummarizedExperiment",
           signature = c(x = "TreeSummarizedExperiment"),
     function(x, ...){
-        
         # If rowTree exists, checks if the rowTree match with rownames:
         # tips labels are found from rownames
         if( !is.null(rowTree(x)) && any(!( rowTree(x)$tip) %in% rownames(x)) ){
@@ -124,16 +118,14 @@ setMethod("makePhyloseqFromTreeSummarizedExperiment",
             )
             warning("rowTree is agglomerated to match rownames.")
         }
-
+        
         # Gets otu_table object from the function above this, if tse contains
         # only abundance table.
         # Otherwise, gets a phyloseq object with otu_table, and tax_table
         # and/or sample_data
         obj <- callNextMethod()
-
         # List of arguments
         args = list()
-
         # Adds to the list of arguments, if 'obj' is not a phyloseq object
         # i.e. is an otu_table
         if(!is(obj,"phyloseq")){
@@ -146,7 +138,6 @@ setMethod("makePhyloseqFromTreeSummarizedExperiment",
         if(!( length(rowTree(x)) == 0 || is.null(rowTree(x)) )){
             phy_tree <- rowTree(x)
             phy_tree <- phyloseq::phy_tree(phy_tree)
-
             # If the object is a phyloseq object, adds phy_tree to it
             if(is(obj,"phyloseq")){
                 phyloseq::phy_tree(obj) <- phy_tree
@@ -161,7 +152,6 @@ setMethod("makePhyloseqFromTreeSummarizedExperiment",
         if(!( length(referenceSeq(x)) == 0 || is.null(referenceSeq(x)) )){
             refseq <- referenceSeq(x)
             refseq <- phyloseq::refseq(refseq)
-
             # If the object is a phyloseq object, adds refseq to it
             if(is(obj,"phyloseq")){
                 obj <- phyloseq::merge_phyloseq(obj, refseq)

--- a/R/makephyloseqFromTreeSummarizedExperiment.R
+++ b/R/makephyloseqFromTreeSummarizedExperiment.R
@@ -109,6 +109,15 @@ setMethod("makePhyloseqFromTreeSummarizedExperiment",
 setMethod("makePhyloseqFromTreeSummarizedExperiment",
           signature = c(x = "TreeSummarizedExperiment"),
     function(x, ...){
+        
+        # If rowTree exists, checks if the rowTree match with rownames:
+        # every taxa is found from tip labels and just once
+        if( !is.null(rowTree(x)) && any(!(rownames(x) %in% rowTree(x)$tip)) && 
+                     length(rowTree(x)$tip) == length(rownames(x)) ){
+            stop("rowTree does not match with rownames. 'x' can not be converted
+                 to a phyloseq object. Check rowTree(x)$tip and rownames(x).",
+                 call. = FALSE)
+        }
 
         # Gets otu_table object from the function above this, if tse contains
         # only abundance table.

--- a/tests/testthat/test-4IO.R
+++ b/tests/testthat/test-4IO.R
@@ -293,6 +293,14 @@ test_that("makePhyloseqFromTreeSummarizedExperiment", {
     # Test that referenceSeq is in refseq. Expect error, because there should not be
     # reference sequences.
     expect_error(phyloseq::refseq(phy))
+    
+    # Test with agglomeration that an error occurs when rowTree is incorrect
+    test1 <- agglomerateByRank(tse, rank = "Phylum")
+    test2 <- expect_warning(agglomerateByRank(tse, rank = "Phylum", agglomerateTree = TRUE))
+    test2_phy <- makePhyloseqFromTreeSummarizedExperiment(test2)
+    
+    expect_error(makePhyloseqFromTreeSummarizedExperiment(test1))
+    expect_equal(phyloseq::phy_tree(test2_phy), rowTree(test2))
 
     # TSE object
     data(esophagus)
@@ -306,7 +314,5 @@ test_that("makePhyloseqFromTreeSummarizedExperiment", {
 
     # Test that rowTree is in phy_tree
     expect_equal(phyloseq::phy_tree(phy), rowTree(tse))
-
-
 
 })

--- a/tests/testthat/test-4IO.R
+++ b/tests/testthat/test-4IO.R
@@ -300,8 +300,10 @@ test_that("makePhyloseqFromTreeSummarizedExperiment", {
     test1_phy <- expect_warning(makePhyloseqFromTreeSummarizedExperiment(test1))
     test2_phy <- makePhyloseqFromTreeSummarizedExperiment(test2)
     
-    expect_equal(phyloseq::phy_tree(test1_phy), rowTree(test2))
-    expect_equal(phyloseq::phy_tree(test1_phy), phyloseq::phy_tree(test2_phy))
+    expect_equal(length(phyloseq::phy_tree(test1_phy)$nodeLabs), 
+                 length(ape::keep.tip(rowTree(test1), rowLinks(test2)$nodeLabs)))
+    expect_equal(phyloseq::phy_tree(test1_phy)$tip.label, rownames(test2))
+    expect_equal(phyloseq::phy_tree(test2_phy), rowTree(test2))
 
     # TSE object
     data(esophagus)

--- a/tests/testthat/test-4IO.R
+++ b/tests/testthat/test-4IO.R
@@ -294,13 +294,14 @@ test_that("makePhyloseqFromTreeSummarizedExperiment", {
     # reference sequences.
     expect_error(phyloseq::refseq(phy))
     
-    # Test with agglomeration that an error occurs when rowTree is incorrect
+    # Test with agglomeration that that pruning is done internally
     test1 <- agglomerateByRank(tse, rank = "Phylum")
     test2 <- expect_warning(agglomerateByRank(tse, rank = "Phylum", agglomerateTree = TRUE))
+    test1_phy <- expect_warning(makePhyloseqFromTreeSummarizedExperiment(test1))
     test2_phy <- makePhyloseqFromTreeSummarizedExperiment(test2)
     
-    expect_error(makePhyloseqFromTreeSummarizedExperiment(test1))
-    expect_equal(phyloseq::phy_tree(test2_phy), rowTree(test2))
+    expect_equal(phyloseq::phy_tree(test1_phy), rowTree(test2))
+    expect_equal(phyloseq::phy_tree(test1_phy), phyloseq::phy_tree(test2_phy))
 
     # TSE object
     data(esophagus)


### PR DESCRIPTION
Hi,

now it is checked that `rowTree` matches with `rownames` in `makePhyloseqFromTreeSummarizedExperiment`.

ISSUE: https://github.com/microbiome/mia/issues/108

Branch `agglomerateTree_TRUE` is related to this issue, so it can be also deleted. 

-Tuomas
