### PR TITLE
meltAssay fix (colData is not added)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.1.10
+Version: 1.1.11
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut", "cre"),
              email = "felix.gm.ernst@outlook.com",

--- a/R/meltAssay.R
+++ b/R/meltAssay.R
@@ -44,8 +44,7 @@
 #'   \item{check_names}{ A boolean value passed to data.frame function's check.name
 #'   argument. Determines if sample names are checked that they are syntactically 
 #'   valid variable names and are not duplicated. If they are not, sample names 
-#'   are modified. \code{check_names = TRUE} disables \code{add_col_data} argument.
-#'   (default: \code{check_names = TRUE})}
+#'   are modified. (default: \code{check_names = TRUE})}
 #' }
 #'
 #' @return A \code{tibble} with the molten data. The assay values are given in a
@@ -103,8 +102,8 @@ setGeneric("meltAssay",
     add_row_data
 }
 
-.norm_add_col_data <- function(add_col_data, x, sample_name, check_names = FALSE){
-    if(is.null(add_col_data) || check_names == TRUE){
+.norm_add_col_data <- function(add_col_data, x, sample_name){
+    if(is.null(add_col_data)){
         return(NULL)
     }
     if(anyNA(add_col_data)){
@@ -182,7 +181,7 @@ setMethod("meltAssay", signature = c(x = "SummarizedExperiment"),
         }
         # check selected colnames
         add_row_data <- .norm_add_row_data(add_row_data, x, feature_name)
-        add_col_data <- .norm_add_col_data(add_col_data, x, sample_name, ...)
+        add_col_data <- .norm_add_col_data(add_col_data, x, sample_name)
         molten_assay <- .melt_assay(x, abund_values, feature_name, sample_name, ...)
         if(!is.null(add_row_data)){
             molten_assay <-

--- a/R/meltAssay.R
+++ b/R/meltAssay.R
@@ -198,7 +198,7 @@ setMethod("meltAssay", signature = c(x = "SummarizedExperiment"),
 #' @importFrom rlang sym
 .melt_assay <- function(x, assay_name, feature_name, sample_name) {
     assay(x, assay_name) %>%
-        data.frame() %>%
+        data.frame(check.names = FALSE) %>%
         rownames_to_column(feature_name) %>%
         # SampleID is unique sample id
         pivot_longer(!sym(feature_name),

--- a/R/meltAssay.R
+++ b/R/meltAssay.R
@@ -191,7 +191,7 @@ setMethod("meltAssay", signature = c(x = "SummarizedExperiment"),
         if(!is.null(add_col_data)){
             molten_assay <-
                 .add_col_data_to_molten_assay(molten_assay, x, add_col_data,
-                                              sample_name)
+                                              sample_name, ...)
         }
         .format_molten_assay(molten_assay, x, feature_name, sample_name)
     }
@@ -237,9 +237,13 @@ setMethod("meltAssay", signature = c(x = "SummarizedExperiment"),
 #' @importFrom tibble rownames_to_column
 #' @importFrom dplyr rename left_join
 .add_col_data_to_molten_assay <- function(molten_assay, x, add_col_data,
-                                          sample_name) {
+                                          sample_name, check_names = FALSE) {
     cd <- SummarizedExperiment::colData(x)[,add_col_data] %>%
         data.frame()
+    # This makes sure that sample names match
+    if(check_names == TRUE){
+        rownames(cd) <- make.names(rownames(cd))
+    }
     if(sample_name %in% add_col_data){
         cd <- cd %>%
             dplyr::rename(!!sym(.col_switch_name(sample_name)) := !!sym(sample_name))

--- a/R/meltAssay.R
+++ b/R/meltAssay.R
@@ -30,7 +30,7 @@
 #'   to given column names in \code{rowData}. (default:
 #'   \code{add_row_data = NULL})
 #'
-#' @param assay_name a \code{character} value to select an
+#' @param abund_values a \code{character} value to select an
 #'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assayNames}}
 #'
 #' @param feature_name a \code{character} scalar to use as the output's name
@@ -49,7 +49,7 @@
 #' }
 #'
 #' @return A \code{tibble} with the molten data. The assay values are given in a
-#' column named like the selected assay \code{assay_name}. In addition, a
+#' column named like the selected assay \code{abund_values}. In addition, a
 #' column \dQuote{FeatureID} will contain the rownames, if set, and analogously
 #' a column \dQuote{SampleID} with the colnames, if set
 #'
@@ -63,7 +63,7 @@
 #' molten_se <- meltAssay(GlobalPatterns,
 #'                        add_row_data = TRUE,
 #'                        add_col_data = TRUE,
-#'                        assay_name = "counts")
+#'                        abund_values = "counts")
 #' molten_se
 NULL
 
@@ -74,7 +74,7 @@ setGeneric("meltAssay",
            function(x,
                     add_row_data = NULL,
                     add_col_data = NULL,
-                    assay_name = "counts", 
+                    abund_values = "counts", 
                     feature_name = "FeatureID",
                     sample_name = "SampleID",
                     ...)
@@ -166,12 +166,12 @@ setMethod("meltAssay", signature = c(x = "SummarizedExperiment"),
     function(x,
              add_row_data = NULL,
              add_col_data = NULL,
-             assay_name = "counts", 
+             abund_values = "counts", 
              feature_name = "FeatureID",
              sample_name = "SampleID",
              ...) {
         # input check
-        .check_assay_present(assay_name, x)
+        .check_assay_present(abund_values, x)
         if(!.is_a_string(feature_name)){
             stop("'feature_name' must be a single non-empty character value.",
                  call. = FALSE)
@@ -183,7 +183,7 @@ setMethod("meltAssay", signature = c(x = "SummarizedExperiment"),
         # check selected colnames
         add_row_data <- .norm_add_row_data(add_row_data, x, feature_name)
         add_col_data <- .norm_add_col_data(add_col_data, x, sample_name, ...)
-        molten_assay <- .melt_assay(x, assay_name, feature_name, sample_name, ...)
+        molten_assay <- .melt_assay(x, abund_values, feature_name, sample_name, ...)
         if(!is.null(add_row_data)){
             molten_assay <-
                 .add_row_data_to_molten_assay(molten_assay, x, add_row_data,
@@ -203,13 +203,13 @@ setMethod("meltAssay", signature = c(x = "SummarizedExperiment"),
 #' @importFrom tibble rownames_to_column
 #' @importFrom tidyr pivot_longer
 #' @importFrom rlang sym
-.melt_assay <- function(x, assay_name, feature_name, sample_name, check_names = FALSE) {
-    assay(x, assay_name) %>%
+.melt_assay <- function(x, abund_values, feature_name, sample_name, check_names = FALSE) {
+    assay(x, abund_values) %>%
         data.frame(check.names = check_names) %>%
         rownames_to_column(feature_name) %>%
         # SampleID is unique sample id
         pivot_longer(!sym(feature_name),
-                     values_to = assay_name,
+                     values_to = abund_values,
                      names_to = sample_name)
 }
 

--- a/R/meltAssay.R
+++ b/R/meltAssay.R
@@ -144,7 +144,7 @@ setGeneric("meltAssay",
        !anyDuplicated(colData(x)[,sample_name])){
         molten_assay %>%
             select(!sym(sample_name)) %>%
-            dplyr::rename(sym(sample_name) := !!sym(.col_switch_name(sample_name)))
+            dplyr::rename(!!sym(sample_name) := !!sym(.col_switch_name(sample_name)))
     }
     molten_assay %>%
         mutate(!!sym(feature_name) := factor(!!sym(feature_name)),

--- a/man/agglomerate-methods.Rd
+++ b/man/agglomerate-methods.Rd
@@ -96,6 +96,16 @@ rowTree(x2) # ... tree
 
 # removing empty labels by setting na.rm = TRUE
 sum(is.na(rowData(GlobalPatterns)$Family))
+x3 <- agglomerateByRank(GlobalPatterns, rank="Family", na.rm = TRUE)
+nrow(x3) # different from x2
+
+# Because all the rownames are from the same rank, rownames do not include 
+# prefixes, in this case "Family:". 
+print(rownames(x3[1:3,]))
+
+# To add them, use getTaxonomyLabels function.
+rownames(x3) <- getTaxonomyLabels(x3, with_rank = TRUE)
+print(rownames(x3[1:3,]))
 
 ## Look at enterotype dataset...
 data(enterotype)

--- a/man/meltAssay.Rd
+++ b/man/meltAssay.Rd
@@ -10,7 +10,7 @@ meltAssay(
   x,
   add_row_data = NULL,
   add_col_data = NULL,
-  assay_name = "counts",
+  abund_values = "counts",
   feature_name = "FeatureID",
   sample_name = "SampleID",
   ...
@@ -20,7 +20,7 @@ meltAssay(
   x,
   add_row_data = NULL,
   add_col_data = NULL,
-  assay_name = "counts",
+  abund_values = "counts",
   feature_name = "FeatureID",
   sample_name = "SampleID",
   ...
@@ -46,7 +46,7 @@ If \code{add_col_data = NULL} no data will be added, if
 to given column names in \code{colData}. (default:
 \code{add_col_data = NULL})}
 
-\item{assay_name}{a \code{character} value to select an
+\item{abund_values}{a \code{character} value to select an
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assayNames}}}
 
 \item{feature_name}{a \code{character} scalar to use as the output's name
@@ -66,7 +66,7 @@ are modified. \code{check_names = TRUE} disables \code{add_col_data} argument.
 }
 \value{
 A \code{tibble} with the molten data. The assay values are given in a
-column named like the selected assay \code{assay_name}. In addition, a
+column named like the selected assay \code{abund_values}. In addition, a
 column \dQuote{FeatureID} will contain the rownames, if set, and analogously
 a column \dQuote{SampleID} with the colnames, if set
 }
@@ -86,7 +86,7 @@ data(GlobalPatterns)
 molten_se <- meltAssay(GlobalPatterns,
                        add_row_data = TRUE,
                        add_col_data = TRUE,
-                       assay_name = "counts")
+                       abund_values = "counts")
 molten_se
 }
 \author{

--- a/man/meltAssay.Rd
+++ b/man/meltAssay.Rd
@@ -60,8 +60,7 @@ for the sample identifier. (default: \code{sample_name = "SampleID"})}
 \item{check_names}{ A boolean value passed to data.frame function's check.name
 argument. Determines if sample names are checked that they are syntactically
 valid variable names and are not duplicated. If they are not, sample names
-are modified. \code{check_names = TRUE} disables \code{add_col_data} argument.
-(default: \code{check_names = TRUE})}
+are modified. (default: \code{check_names = TRUE})}
 }}
 }
 \value{

--- a/man/meltAssay.Rd
+++ b/man/meltAssay.Rd
@@ -55,7 +55,14 @@ for the feature identifier. (default: \code{feature_name = "FeatureID"})}
 \item{sample_name}{a \code{character} scalar to use as the output's name
 for the sample identifier. (default: \code{sample_name = "SampleID"})}
 
-\item{...}{optional arguments currently not used.}
+\item{...}{optional arguments:
+\itemize{
+\item{check_names}{ A boolean value passed to data.frame function's check.name
+argument. Determines if sample names are checked that they are syntactically
+valid variable names and are not duplicated. If they are not, sample names
+are modified. \code{check_names = TRUE} disables \code{add_col_data} argument.
+(default: \code{check_names = TRUE})}
+}}
 }
 \value{
 A \code{tibble} with the molten data. The assay values are given in a

--- a/tests/testthat/test-0utilites.R
+++ b/tests/testthat/test-0utilites.R
@@ -36,12 +36,12 @@ test_that("meltAssay", {
     molten_assay <- meltAssay(se,
                               add_row_data = TRUE,
                               add_col_data = c("X.SampleID", "Primer"),
-                              assay_name = "counts")
+                              abund_values = "counts")
     expect_s3_class(molten_assay, c("tbl_df","tbl","data.frame"))
     expect_equal(colnames(molten_assay)[c(1:4,11)], c("FeatureID","SampleID","counts","Kingdom","X.SampleID"))
     expect_equal(is.numeric(molten_assay$counts), TRUE)
 
-    only_assay <- meltAssay(se, assay_name = "counts")
+    only_assay <- meltAssay(se, abund_values = "counts")
     expect_equal(colnames(only_assay)[1:3], c("FeatureID","SampleID","counts"))
     expect_equal(is.numeric(only_assay$counts), TRUE)
 

--- a/tests/testthat/test-0utilites.R
+++ b/tests/testthat/test-0utilites.R
@@ -73,6 +73,21 @@ test_that("meltAssay", {
     actual3 <- meltAssay(x3, TRUE, TRUE)
     expect_false("FeatureID_row" %in% colnames(actual))
     expect_false("SampleID_col" %in% colnames(actual))
+    #
+    x4 <- se
+    # Change names to 1, 2, 3... format
+    colnames(x4) <- seq_along(colnames(x4))
+    melted <- meltAssay(x4, abund_values = "counts", add_col_data = TRUE)
+    melted2 <- meltAssay(x4, abund_values = "counts", add_col_data = TRUE, 
+                         check_names = TRUE)
+    # There should not be any NAs
+    expect_true(any(!(is.na(melted))))
+    expect_true(any(!(is.na(melted2))))
+    # Remove prefix from sample names
+    melted2$SampleID <- as.factor(gsub(pattern = "X", 
+                                       replacement = "", 
+                                       x = melted2$SampleID))
+    expect_equal(melted, melted2)
 })
 
 context("getAbundanceFeature/getAbundanceSample")

--- a/vignettes/mia.Rmd
+++ b/vignettes/mia.Rmd
@@ -294,7 +294,7 @@ To generate tidy data as used and required in most of the tidyverse,
 molten_data <- meltAssay(se,
                          add_row_data = TRUE,
                          add_col_data = TRUE,
-                         assay_name = "counts")
+                         abund_values = "counts")
 molten_data
 ```
 

--- a/vignettes/mia.Rmd
+++ b/vignettes/mia.Rmd
@@ -294,7 +294,7 @@ To generate tidy data as used and required in most of the tidyverse,
 molten_data <- meltAssay(se,
                          add_row_data = TRUE,
                          add_col_data = TRUE,
-                         abund_values = "counts")
+                         assay_name = "counts")
 molten_data
 ```
 


### PR DESCRIPTION
Hi,

I found a bug from `meltAssay`.

**Problem:** 
When `colnames` are in format "1", "2"..., they get prefix "X" when `assay` is melted. E.g., "1" --> "X1". That is because, `data.frame `function checks column names that they are syntactically valid and not duplicated, and "1" is not valid.  

Because prefix is added to non-valid names, `colData` and `melted assay` do not match anymore. --> **`left_join` does not work, and `colData` is not added to `melted data`.** 

Because IDs in format "1" are so common, I think this is a problem.

Example:
```
library(mia)

data("GlobalPatterns")

tse <- GlobalPatterns
tse2 <- tse

# Change the colnames
colnames(tse2) <- seq_along(colnames(tse2))

meltAssay(tse, assay_name = "counts", add_col_data = TRUE)
meltAssay(tse2, assay_name = "counts", add_col_data = TRUE)
```

**Solution:** 
I think that check is not necessary, and it can be disabled. This PR disables it.

-Tuomas

 
