### PR TITLE
Fix bug in loadFromQIIME2()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.1.11
+Version: 1.1.12
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut", "cre"),
              email = "felix.gm.ernst@outlook.com",

--- a/R/loadFromQIIME2.R
+++ b/R/loadFromQIIME2.R
@@ -128,6 +128,14 @@ loadFromQIIME2 <- function(featureTableFile,
 
     if (!is.null(sampleMetaFile)) {
         sample_meta <- .read_q2sample_meta(sampleMetaFile)
+        if (nrow(sample_meta) != ncol(feature_tab)
+         || !setequal(rownames(sample_meta), colnames(feature_tab)))
+            stop("The sample ids in sample metadata file:\n",
+                 "    ", sampleMetaFile, "\n",
+                 "  are incompatible with those in feature table file:\n",
+                 "    ", featureTableFile)
+        if (!identical(rownames(sample_meta), colnames(feature_tab)))
+            sample_meta <- sample_meta[colnames(feature_tab), , drop = FALSE]
     } else {
         sample_meta <- S4Vectors:::make_zero_col_DataFrame(ncol(feature_tab))
     }


### PR DESCRIPTION
`loadFromQIIME2()` now checks that the sample ids in the supplied sample metadata file are compatible with those in the supplied feature table file, and align them if necessary.

This fixes https://bioconductor.org/checkResults/3.14/bioc-LATEST/mia/nebbiolo2-checksrc.html