### PR TITLE
makePseqFromTreeSE, factors in taxonomy table converted to characters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.1.14
+Version: 1.1.15
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut", "cre"),
              email = "felix.gm.ernst@outlook.com",

--- a/R/makephyloseqFromTreeSummarizedExperiment.R
+++ b/R/makephyloseqFromTreeSummarizedExperiment.R
@@ -82,6 +82,8 @@ setMethod("makePhyloseqFromTreeSummarizedExperiment",
         # If rowData includes information
         if(!( length(rowData(x)[,taxonomyRanks(x)]) == 0 ||
               is.null((rowData(x)[,taxonomyRanks(x)])) )){
+            # Converts taxonomy table to characters if it's not already
+            rowData(x) <- DataFrame(lapply(rowData(x), as.character))
             # Gets the taxonomic data from rowData, and converts it to tax_table
             tax_table <- as.matrix(rowData(x)[,taxonomyRanks(x)])
             tax_table <- phyloseq::tax_table(tax_table)

--- a/tests/testthat/test-4IO.R
+++ b/tests/testthat/test-4IO.R
@@ -352,15 +352,21 @@ test_that("makePhyloseqFromTreeSummarizedExperiment", {
         expect_warning(makePhyloseqFromTreeSummarizedExperiment(temp))
     }
     
+    tse2 <- tse
+    # Concerts data frame to factors
+    rowData(tse2) <- DataFrame(lapply(rowData(tse2), as.factor))
+    phy <- makePhyloseqFromTreeSummarizedExperiment(tse)
+    phy2 <- makePhyloseqFromTreeSummarizedExperiment(tse2)
+    expect_equal(phyloseq::tax_table(phy2), phyloseq::tax_table(phy))
+    
     # TSE object
     data(esophagus)
     tse <- esophagus
 
-    phy <- makePhyloseqFromTreeSummarizedExperiment(esophagus)
+    phy <- makePhyloseqFromTreeSummarizedExperiment(tse)
 
     # Test that assay is in otu_table
     expect_equal(as.data.frame(phyloseq::otu_table(phy)@.Data), as.data.frame(assays(tse)$counts))
-
 
     # Test that rowTree is in phy_tree
     expect_equal(phyloseq::phy_tree(phy), rowTree(tse))


### PR DESCRIPTION
Hi, 

this fixes the issue: https://github.com/microbiome/mia/issues/144

Problem: `phyloseq`'s taxonomy table allows only `characters`. `TreeSE` allows also `factors` --> error

Solution: taxonomy table's columns are converted to characters.

-Tuomas