### PR TITLE
meltAssay fix (duplicated rownames)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.1.17
+Version: 1.1.18
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut", "cre"),
              email = "felix.gm.ernst@outlook.com",

--- a/NEWS
+++ b/NEWS
@@ -11,3 +11,4 @@ Changes in version 1.1.x (2021-06-04)
 + added estimateDivergence
 + bugfix: makePhyloseqFromTreeSummarizedExperiment checks now for rowTree be compatible
 + bugfix: meltAssay supports Matrix types
++ bugfix: meltAssay is able to include rowData also when there are duplicated rownames

--- a/R/meltAssay.R
+++ b/R/meltAssay.R
@@ -182,7 +182,7 @@ setMethod("meltAssay", signature = c(x = "SummarizedExperiment"),
         }
         # check if rownames are duplicated, and if they are, modify
         if( any(duplicated(rownames(x))) ){
-            rownames(x) <- getTaxonomyLabels(x)
+            rownames(x) <- make.unique(rownames(x))
             warning("rownames(x) included duplicates.",
                     " rownames(x) are made unique. ",
                     call. = FALSE)

--- a/R/meltAssay.R
+++ b/R/meltAssay.R
@@ -183,6 +183,9 @@ setMethod("meltAssay", signature = c(x = "SummarizedExperiment"),
         # check if rownames are duplicated, and if they are, modify
         if( any(duplicated(rownames(x))) ){
             rownames(x) <- getTaxonomyLabels(x)
+            warning("rownames(x) included duplicates.",
+                    " rownames(x) are made unique. ",
+                    call. = FALSE)
         }
         # check selected colnames
         add_row_data <- .norm_add_row_data(add_row_data, x, feature_name)

--- a/R/meltAssay.R
+++ b/R/meltAssay.R
@@ -180,12 +180,9 @@ setMethod("meltAssay", signature = c(x = "SummarizedExperiment"),
             stop("'sample_name' must be a single non-empty character value.",
                  call. = FALSE)
         }
-        # check if names are duplicated, and if they are, change
+        # check if rownames are duplicated, and if they are, modify
         if( any(duplicated(rownames(x))) ){
-            rownames(x) <- make.names(rownames(x))
-        }
-        if( any(duplicated(colnames(x))) ){
-            colnames(x) <- make.names(colnames(x))
+            rownames(x) <- getTaxonomyLabels(x)
         }
         # check selected colnames
         add_row_data <- .norm_add_row_data(add_row_data, x, feature_name)

--- a/R/meltAssay.R
+++ b/R/meltAssay.R
@@ -180,6 +180,13 @@ setMethod("meltAssay", signature = c(x = "SummarizedExperiment"),
             stop("'sample_name' must be a single non-empty character value.",
                  call. = FALSE)
         }
+        # check if names are duplicated, and if they are, change
+        if( any(duplicated(rownames(x))) ){
+            rownames(x) <- make.names(rownames(x))
+        }
+        if( any(duplicated(colnames(x))) ){
+            colnames(x) <- make.names(colnames(x))
+        }
         # check selected colnames
         add_row_data <- .norm_add_row_data(add_row_data, x, feature_name)
         add_col_data <- .norm_add_col_data(add_col_data, x, sample_name)


### PR DESCRIPTION
Hi!

Problem: `SE` can have duplicated rownames. When assay is converted into `data.frame` in melting step, names are modified if there are any duplicated names. --> missmatch with original `SE` object (and its `rowData`) and melted data --> taxonomic data is not assigned to melted data

Solution: If data contains duplicated names, they are first modified so that they are unique. 

Issue: https://github.com/microbiome/mia/issues/155

-Tuomas