### PR TITLE
taxonomyTree bugfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.3.7
+Version: 1.3.8
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut", "cre"),
              email = "felix.gm.ernst@outlook.com",

--- a/NEWS
+++ b/NEWS
@@ -18,3 +18,4 @@ Changes in version 1.1.x (2021-06-04)
 + getUniqueTaxa & getTopTaxa: added option for alphabetical order
 + name change: testForExperimentCrossCorrelation to testExperimentCrossCorrelation
 + getExperimentCrossCorrelation: Filtering disabled by default, option to suppress warnings
++ bugfix: taxonomyTree gave error when taxa were agglomerated at highest level (taxa name mismatch)

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -379,9 +379,10 @@ setGeneric("taxonomyTree",
 #' @export
 setMethod("taxonomyTree", signature = c(x = "SummarizedExperiment"),
     function(x){
-        td <- rowData(x)[,taxonomyRanks(x)]
+        # Converted to data.frame so that drop = FALSE is enabled
+        td <- data.frame(rowData(x)[,taxonomyRanks(x)])
         # Remove empty taxonomic levels
-        td <- td[,!vapply(td,function(tl){all(is.na(tl))},logical(1))]
+        td <- td[,!vapply(td,function(tl){all(is.na(tl))},logical(1)), drop = FALSE]
         # Make information unique
         td_NA <- DataFrame(lapply(td,is.na))
         td <- as.data.frame(td)


### PR DESCRIPTION
Hi!

**Problem:** 
When data is agglomerated at highest level, there were only one column in `rowData` that included information. That information is used to build a tree. 

Because there were only one column, information was vector after subsetting and it did not include column names anymore. 

**Solution:** 
I used `drop = FALSE`, so that column names are included after subsetting

Issue: https://github.com/microbiome/mia/issues/174

-Tuomas