### PR TITLE
Fix getExperimentCrossCorrelation examples

### DIFF
--- a/R/getExperimentCrossCorrelation.R
+++ b/R/getExperimentCrossCorrelation.R
@@ -101,7 +101,9 @@
 #' altExp(tse, "exp2") <- mae[[2]]
 #' 
 #' # When mode = matrix, matrix is returned
-#' result <- getExperimentCrossCorrelation(tse, y = "exp2", method = "pearson", 
+#' result <- getExperimentCrossCorrelation(tse, 
+#'                                         experiment2 = "exp2",
+#'                                         method = "pearson", 
 #'                                         mode = "matrix")
 #' # Show first 5 entries
 #' head(result, 5)
@@ -110,7 +112,9 @@
 #' # filter_self_correlations = TRUE filters self correlations
 #' # With p_adj_threshold it is possible to filter those features that do no have
 #' # any correlations that have p-value under threshold
-#' result <- testExperimentCrossCorrelation(tse, y = tse, method = "pearson",
+#' result <- testExperimentCrossCorrelation(tse, 
+#'                                          experiment2 = tse, 
+#'                                          method = "pearson",
 #'                                          filter_self_correlations = TRUE,
 #'                                          p_adj_threshold = 0.05)
 #' # Show first 5 entries
@@ -119,9 +123,13 @@
 #' # Also getExperimentCrossCorrelation returns significances when 
 #' # test_signicance = TRUE
 #' # Warnings can be suppressed by using show_warnings = FALSE
-#' result <- getExperimentCrossCorrelation(mae[[1]], y = mae[[2]], method = "pearson",
-#'                                         mode = "matrix", test_significance = TRUE,
+#' result <- getExperimentCrossCorrelation(mae[[1]], 
+#'                                         experiment2 = mae[[2]], 
+#'                                         method = "pearson",
+#'                                         mode = "matrix", 
+#'                                         test_significance = TRUE,
 #'                                         show_warnings = FALSE)
+#'                                         
 #' # Returned value is a list of matrices
 #' names(result)
 NULL

--- a/man/getExperimentCrossCorrelation.Rd
+++ b/man/getExperimentCrossCorrelation.Rd
@@ -135,7 +135,9 @@ tse <- mae[[1]]
 altExp(tse, "exp2") <- mae[[2]]
 
 # When mode = matrix, matrix is returned
-result <- getExperimentCrossCorrelation(tse, y = "exp2", method = "pearson", 
+result <- getExperimentCrossCorrelation(tse, 
+                                        experiment2 = "exp2",
+                                        method = "pearson", 
                                         mode = "matrix")
 # Show first 5 entries
 head(result, 5)
@@ -144,7 +146,9 @@ head(result, 5)
 # filter_self_correlations = TRUE filters self correlations
 # With p_adj_threshold it is possible to filter those features that do no have
 # any correlations that have p-value under threshold
-result <- testExperimentCrossCorrelation(tse, y = tse, method = "pearson",
+result <- testExperimentCrossCorrelation(tse, 
+                                         experiment2 = tse, 
+                                         method = "pearson",
                                          filter_self_correlations = TRUE,
                                          p_adj_threshold = 0.05)
 # Show first 5 entries
@@ -153,9 +157,13 @@ head(result, 5)
 # Also getExperimentCrossCorrelation returns significances when 
 # test_signicance = TRUE
 # Warnings can be suppressed by using show_warnings = FALSE
-result <- getExperimentCrossCorrelation(mae[[1]], y = mae[[2]], method = "pearson",
-                                        mode = "matrix", test_significance = TRUE,
+result <- getExperimentCrossCorrelation(mae[[1]], 
+                                        experiment2 = mae[[2]], 
+                                        method = "pearson",
+                                        mode = "matrix", 
+                                        test_significance = TRUE,
                                         show_warnings = FALSE)
+                                        
 # Returned value is a list of matrices
 names(result)
 }


### PR DESCRIPTION
Hi,

this fixes an example of usage of `getExperimentCrossCorrelation`. 

There was argument `y`, but the right one is `experiment2`

-Tuomas