### PR TITLE
Get top taxa rank option

### DIFF
--- a/man/summaries.Rd
+++ b/man/summaries.Rd
@@ -16,7 +16,8 @@ getTopTaxa(
   top = 5L,
   method = c("mean", "sum", "median"),
   abund_values = "counts",
-  na.rm = TRUE,
+  remove_na = TRUE,
+  rank = NULL,
   ...
 )
 
@@ -25,7 +26,8 @@ getTopTaxa(
   top = 5L,
   method = c("mean", "sum", "median", "prevalence"),
   abund_values = "counts",
-  na.rm = TRUE,
+  remove_na = TRUE,
+  rank = NULL,
   ...
 )
 
@@ -53,14 +55,14 @@ median or prevalence. Default is 'mean'.}
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assayNames}}
 By default it expects count data.}
 
-\item{na.rm}{For \code{getTopTaxa} logical argument for calculation method
+\item{remove_na}{For \code{getTopTaxa} logical argument for calculation method
 specified to argument \code{method}. Default is TRUE.}
-
-\item{...}{Additional arguments passed on to \code{agglomerateByRank()} when
-\code{rank} is specified for \code{countDominantTaxa}.}
 
 \item{rank}{A single character defining a taxonomic rank. Must be a value of
 the output of \code{taxonomyRanks()}.}
+
+\item{...}{Additional arguments passed on to \code{agglomerateByRank()} when
+\code{rank} is specified for \code{countDominantTaxa}.}
 
 \item{group}{With group, it is possible to group the observations in an
 overview. Must be one of the column names of \code{colData}.}
@@ -103,10 +105,14 @@ object.
 }
 \examples{
 data(GlobalPatterns)
+
+# Get top genera
 top_taxa <- getTopTaxa(GlobalPatterns,
                        method = "mean",
                        top = 5,
-                       abund_values = "counts")
+                       abund_values = "counts",
+                       rank = "Genus",
+                       na.rm = TRUE)
 top_taxa
 
 # Gets the overview of dominant taxa

--- a/tests/testthat/test-0utilites.R
+++ b/tests/testthat/test-0utilites.R
@@ -146,4 +146,20 @@ test_that("getTopTaxa", {
     expect_equal(top_mean, mean.taxa)
     expect_equal(top_sum, sum.taxa)
     expect_equal(top_median, median.taxa)
+    # Test agglomeration option
+    tse <- GlobalPatterns
+    tse <- agglomerateByRank(tse, rank = "Phylum")
+    mat <- assay(tse)
+    rowsums <- rowSums2(mat)
+    top_taxa_ref <- rownames(tse)[order(rowsums, decreasing = T)][1:5]
+    top_taxa <- getTopTaxa(GlobalPatterns, rank = "Phylum", top = 5, method = "sum")
+    expect_equal(top_taxa, top_taxa_ref)
+    # Test agglomeration option with na.rm
+    tse <- GlobalPatterns
+    tse <- agglomerateByRank(tse, rank = "Genus", na.rm = T)
+    mat <- assay(tse)
+    rowmedians <- rowMedians(mat)
+    top_taxa_ref <- rownames(tse)[order(rowmedians, decreasing = T)][1:20]
+    top_taxa <- getTopTaxa(GlobalPatterns, rank = "Genus", top = 20, na.rm = T,  method = "median")
+    expect_equal(top_taxa, top_taxa_ref)
 })


### PR DESCRIPTION
Hi,

I added rank option to `getTopTaxa`. 

We use `na.rm` in two places. 

1. To remove NAs when calculating, e.g., rowsums
2. To remove NAs while agglomerating

In other summary functions, na.rm is used as a hidden (`...`) argument for `agglomerateByRank` (option 2), so I changed na.rm (option 1) to `remove_na`. 

Issue: https://github.com/microbiome/mia/issues/212

-Tuomas