### PR TITLE
Crosscorr bugfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.3.18
+Version: 1.3.19
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut", "cre"),
              email = "felix.gm.ernst@outlook.com",

--- a/NEWS
+++ b/NEWS
@@ -27,3 +27,4 @@ Changes in version 1.3.x
 + added na.rm option to getTopTaxa function   
 + bugfix: makeTreeSEFromPseq -- orientation of assay is taken into account
 + bugfix: getExperimentCrossCorrelation's "matrix"" mode works with features named equally
++ bugfix: getExperimentCrossCorrelation's calculates correlations correctly with features named equally

--- a/R/getExperimentCrossCorrelation.R
+++ b/R/getExperimentCrossCorrelation.R
@@ -452,6 +452,20 @@ setMethod("testExperimentCrossCorrelation", signature = c(x = "ANY"),
         FUN <- .calculate_correlation_for_categorical_values
     }
     
+    # If assays includes features named equally, this causes problems. 
+    # Change names unique if there are equal names, and store original names
+    assay_names_ununique <- FALSE
+    if( any(duplicated(colnames(assay1))) || any(duplicated(colnames(assay2))) ){
+        # Create feature_pairs from original names
+        feature_pairs_original <- expand.grid(colnames(assay1), colnames(assay2))
+        # assay1
+        colnames(assay1) <- make.unique(colnames(assay1))
+        # assay2
+        colnames(assay2) <- make.unique(colnames(assay2))
+        # Ununique names were found
+        assay_names_ununique <- TRUE
+    }
+    
     # Get all the sample pairs
     feature_pairs <- expand.grid(colnames(assay1), colnames(assay2))
     # Calculate correlations
@@ -462,6 +476,12 @@ setMethod("testExperimentCrossCorrelation", signature = c(x = "ANY"),
                                        assay2 = assay2,
                                        method = method,
                                        show_warnings = show_warnings)
+    
+    # If there were equal names, feature_pairs include mutated names. 
+    # If so, convert them back to original
+    if( assay_names_ununique ){
+        feature_pairs <- feature_pairs_original
+    }
     
     # Convert into data.frame if it is vector, 
     # otherwise transpose into the same orientation as feature-pairs if it's not a vector

--- a/tests/testthat/test-5getExperimentCrossCorrelation.R
+++ b/tests/testthat/test-5getExperimentCrossCorrelation.R
@@ -259,27 +259,36 @@ test_that("getExperimentCrossCorrelation", {
     # Values should be the same
     expect_equal(round(result, 4), round(ref, 4))
     
-    mae <- mae[1:10, 1:10]
+    mae2 <- mae[1:10, 1:10]
     # Test that output is in correct type
     expect_true( is.data.frame(suppressWarnings(
-        testExperimentCrossCorrelation(mae, p_adj_threshold = NULL))) )
+        testExperimentCrossCorrelation(mae2, p_adj_threshold = NULL))) )
     expect_true( is.data.frame(suppressWarnings(
-        getExperimentCrossCorrelation(mae, test_significance = TRUE, p_adj_threshold = NULL))) )
-    expect_true( is.data.frame(getExperimentCrossCorrelation(mae)) )
+        getExperimentCrossCorrelation(mae2, test_significance = TRUE, p_adj_threshold = NULL))) )
+    expect_true( is.data.frame(getExperimentCrossCorrelation(mae2)) )
     # There should not be any p-values that are under 0
     expect_true( is.null(suppressWarnings(
-        testExperimentCrossCorrelation(mae, p_adj_threshold = 0))) )
+        testExperimentCrossCorrelation(mae2, p_adj_threshold = 0))) )
     # Test that output is in correct type
     expect_true( is.list(suppressWarnings(
-        testExperimentCrossCorrelation(mae, mode = "matrix", 
+        testExperimentCrossCorrelation(mae2, mode = "matrix", 
                                           p_adj_threshold = NULL))) )
     expect_true( is.list(suppressWarnings(
-        getExperimentCrossCorrelation(mae, test_significance = TRUE, 
+        getExperimentCrossCorrelation(mae2, test_significance = TRUE, 
                                       mode = "matrix", p_adj_threshold = NULL))) )
-    expect_true( is.matrix(getExperimentCrossCorrelation(mae, mode = "matrix")) )
+    expect_true( is.matrix(getExperimentCrossCorrelation(mae2, mode = "matrix")) )
     # There should not be any p-values that are under 0
     expect_true( is.null(suppressWarnings(
-        testExperimentCrossCorrelation(mae, p_adj_threshold = 0, mode = "matrix"))) )
+        testExperimentCrossCorrelation(mae2, p_adj_threshold = 0, mode = "matrix"))) )
     
+    # Test that result does not depend on names (if there are equal names)
+    tse <- mae[[1]]
+    rownames(tse)[1:10] <- rep("Unknown", 10)
+    # show_warning does not work currently, 
+    # PR https://github.com/microbiome/mia/pull/195 fixes it
+    # Remove suppressWarnings after it has been merged
+    suppressWarnings( cor_table <- testExperimentCrossCorrelation(tse, show_warnings = TRUE) )
+    suppressWarnings( cor_table_ref <- testExperimentCrossCorrelation(mae[[1]], show_warnings = TRUE) )
+    expect_equal(cor_table[ , 3:5], cor_table_ref[ , 3:5])
 })
 


### PR DESCRIPTION
Hi,

I found out that https://github.com/microbiome/mia/pull/188 does not fix all the problems related to equally named features. Currently, table is correctly converted into matrices: there are as many rows and columns as there are features etc...

However, the calculations are incorrect. 

assay contains multiple "Unknown" samples --> feature-pairs are created based on that --> there are multiple "Unknown vs variable 1" pairs for example --> function takes first "Unknown" feature even though that might not be the correct "Unknown" feature

For example, now all "Unknown" vs "Unknown" pairs have correlation 1. 

I solved this issue by calculating correlations with indices not with names. 

-Tuomas