### PR TITLE
calculateRDA fix

### DIFF
--- a/R/runCCA.R
+++ b/R/runCCA.R
@@ -37,7 +37,7 @@
 #' @param name String specifying the name to be used to store the result in the
 #'   reducedDims of the output.
 #'
-#' @param ... additional arguments not used.
+#' @param ... additional arguments passed to vegan::cca or vegan::rda .
 #'
 #' @return
 #' For \code{calculateCCA} a matrix with samples as rows and CCA dimensions as
@@ -99,7 +99,7 @@ setGeneric("runRDA", signature = c("x"),
 }
 
 #' @importFrom stats as.formula
-.calculate_cca <- function(x, formula, variables, scale = TRUE){
+.calculate_cca <- function(x, formula, variables, scale = TRUE, ...){
     .require_package("vegan")
     # input check
     if(!.is_a_bool(scale)){
@@ -114,13 +114,13 @@ setGeneric("runRDA", signature = c("x"),
         # recast formula in current environment
         form <- as.formula(paste(as.character(formula)[c(2,1,3)],
                                  collapse = " "))
-        cca <- vegan::cca(form, data = variables, scale = scale)
+        cca <- vegan::cca(form, data = variables, scale = scale, ...)
         X <- cca$CCA
     } else if(ncol(variables) > 0L) {
-        cca <- vegan::cca(X = x, Y = variables, scale = scale)
+        cca <- vegan::cca(X = x, Y = variables, scale = scale, ...)
         X <- cca$CCA
     } else {
-        cca <- vegan::cca(X = x, scale = scale)
+        cca <- vegan::cca(X = x, scale = scale, ...)
         X <- cca$CA
     }
     ans <- X$u

--- a/R/runCCA.R
+++ b/R/runCCA.R
@@ -198,7 +198,7 @@ setMethod("runCCA", "SingleCellExperiment",
         rda <- vegan::rda(X = x, Y = variables, scale = scale, ...)
         X <- rda$CCA
     } else {
-        rda <- vegan::rda(X = x, scale = scale)
+        rda <- vegan::rda(X = x, scale = scale, ...)
         X <- rda $CA
     }
     ans <- X$u

--- a/R/runCCA.R
+++ b/R/runCCA.R
@@ -177,7 +177,7 @@ setMethod("runCCA", "SingleCellExperiment",
     }
 )
 
-.calculate_rda <- function(x, formula, variables, scale = TRUE){
+.calculate_rda <- function(x, formula, variables, scale = TRUE, ...){
     .require_package("vegan")
     # input check
     if(!.is_a_bool(scale)){
@@ -192,10 +192,10 @@ setMethod("runCCA", "SingleCellExperiment",
         # recast formula in current environment
         form <- as.formula(paste(as.character(formula)[c(2,1,3)],
                                  collapse = " "))
-        rda <- vegan::rda(form, data = variables, scale = scale)
+        rda <- vegan::rda(form, data = variables, scale = scale, ...)
         X <- rda$CCA
     } else if(ncol(variables) > 0L) {
-        rda <- vegan::rda(X = x, Y = variables, scale = scale)
+        rda <- vegan::rda(X = x, Y = variables, scale = scale, ...)
         X <- rda$CCA
     } else {
         rda <- vegan::rda(X = x, scale = scale)

--- a/man/runCCA.Rd
+++ b/man/runCCA.Rd
@@ -21,7 +21,7 @@ calculateRDA(x, ...)
 
 runRDA(x, ...)
 
-\S4method{calculateCCA}{ANY}(x, formula, variables, scale = TRUE)
+\S4method{calculateCCA}{ANY}(x, formula, variables, scale = TRUE, ...)
 
 \S4method{calculateCCA}{SummarizedExperiment}(
   x,
@@ -33,7 +33,7 @@ runRDA(x, ...)
 
 \S4method{runCCA}{SingleCellExperiment}(x, ..., altexp = NULL, name = "CCA")
 
-\S4method{calculateRDA}{ANY}(x, formula, variables, scale = TRUE)
+\S4method{calculateRDA}{ANY}(x, formula, variables, scale = TRUE, ...)
 
 \S4method{calculateRDA}{SummarizedExperiment}(
   x,
@@ -54,7 +54,7 @@ For \code{runCCA} a
 \code{\link[SingleCellExperiment:SingleCellExperiment]{SingleCellExperiment}}
 or a derived object.}
 
-\item{...}{additional arguments not used.}
+\item{...}{additional arguments passed to vegan::cca or vegan::rda .}
 
 \item{formula}{If \code{x} is a
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}


### PR DESCRIPTION
Hi,

```
data("GlobalPatterns")
tse <- GlobalPatterns
colData(tse)$SampleType[1] <- NA
a <- calculateRDA(tse, data ~ SampleType, na.action = na.omit)
```

Since `na.action` is not passed through, this causes an error. This PR fixes that, however, this is still just a draft, I have to check those other functions also and check that this change does not cause other problems.

-Tuomas

