### PR TITLE
Fix runRDA/runCCA

### DIFF
--- a/R/runCCA.R
+++ b/R/runCCA.R
@@ -192,7 +192,7 @@ setMethod("runCCA", "SingleCellExperiment",
         cca <- calculateCCA(y, ...)
         # If samples do not match / there were samples without appropriate metadata
         # and they are now removed
-        if( rownames(cca) != colnames(x) ){
+        if( all(rownames(cca) != colnames(x)) ){
             # Take a subset
             x_sub <- x[ , rownames(cca) ]
             # Add CCA
@@ -270,7 +270,7 @@ setMethod("runRDA", "SingleCellExperiment",
         rda <- calculateRDA(y, ...)
         # If samples do not match / there were samples without appropriate metadata
         # and they are now removed
-        if( rownames(rda) != colnames(x) ){
+        if( all(rownames(rda) != colnames(x)) ){
             # Take a subset
             x_sub <- x[ , rownames(rda) ]
             # Add RDA

--- a/R/runCCA.R
+++ b/R/runCCA.R
@@ -188,7 +188,23 @@ setMethod("runCCA", "SingleCellExperiment",
         } else {
           y <- x
         }
-        reducedDim(x, name) <- calculateCCA(y, ...)
+        # Calculate CCA
+        cca <- calculateCCA(y, ...)
+        # If samples do not match / there were samples without appropriate metadata
+        # and they are now removed
+        if( rownames(cca) != colnames(x) ){
+            # Take a subset
+            x_sub <- x[ , rownames(cca) ]
+            # Add CCA
+            reducedDim(x_sub, name) <- cca
+            # Add subset to altExp
+            altExp(x, name) <- x_sub
+            # Give a message
+            message("After CCA, certain samples are removed. Subsetted object with ",
+                    "results of CCA analysis is stored in altExp.")
+        } else{
+            reducedDim(x, name) <- cca
+        }
         x
     }
 )
@@ -250,7 +266,23 @@ setMethod("runRDA", "SingleCellExperiment",
         } else {
           y <- x
         }
-        reducedDim(x, name) <- calculateRDA(y, ...)
+        # Calculate RDA
+        rda <- calculateRDA(y, ...)
+        # If samples do not match / there were samples without appropriate metadata
+        # and they are now removed
+        if( rownames(rda) != colnames(x) ){
+            # Take a subset
+            x_sub <- x[ , rownames(rda) ]
+            # Add RDA
+            reducedDim(x_sub, name) <- rda
+            # Add subset to altExp
+            altExp(x, name) <- x_sub
+            # Give a message
+            message("After RDA, certain samples are removed. Subsetted object with ",
+                    "results of RDA analysis is stored in altExp.")
+        } else{
+            reducedDim(x, name) <- rda
+        }
         x
     }
 )


### PR DESCRIPTION
When samples do not have all the metadata, they are removed in RDA/CCA analysis --> samples do not match with TreeSE, and they cannot be stored in reducedDim


This is now solved by taking a subset and storing the subset into altExp

```
library(mia)
if(!require("stringr")){
    install.packages("stringr")
    library("stringr")
}
# Load data
data(enterotype)
# Covariates that are being analyzed
variable_names <- c("ClinicalStatus", "Gender", "Age")

# Apply relative transform
enterotype <- transformSamples(enterotype, method = "relabundance")
# Apply scaling
enterotype <- transformFeatures(enterotype, abund_values = "relabundance", method = "z")

# Create a formula
formula <- as.formula(paste0("data ~ ", str_c(variable_names, collapse = " + ")) )

# runRDA does not match because samples do not match (not all have metadata= Update runRDA to store result to altEXP?)
# # Perform RDA
rda <- calculateRDA(enterotype, 
                    formula = formula, 
                    abund_values = "z", 
                    na.action = na.exclude
)
rda
rda <- runRDA(enterotype, 
                    formula = formula, 
                    abund_values = "z", 
                    na.action = na.exclude
)

```