### PR TITLE
Update error message

### DIFF
--- a/R/getExperimentCrossAssociation.R
+++ b/R/getExperimentCrossAssociation.R
@@ -1005,8 +1005,9 @@ setMethod("getExperimentCrossCorrelation", signature = c(x = "ANY"),
           do.call(association_FUN, args = c(list(feature_mat), list(...)))
       },
       error = function(cond) {
-          stop(paste0("Error occurred during calculation. Check that 
-                      'association_FUN' fulfills requirements."), 
+          stop(paste0("Error occurred during calculation. Check, e.g., that ",
+                      "'association_FUN' fulfills requirements. 'association_FUN' ",
+                      "threw a following error:\n",  cond),
               call. = FALSE)
       }
       )
@@ -1015,8 +1016,9 @@ setMethod("getExperimentCrossCorrelation", signature = c(x = "ANY"),
           suppressWarnings( do.call(association_FUN, args = c(list(feature_mat), list(...))) )
       },
       error = function(cond) {
-          stop(paste0("Error occurred during calculation. Check that ",
-                      "'association_FUN' fulfills requirements."), 
+          stop(paste0("Error occurred during calculation. Check, e.g., that ",
+                      "'association_FUN' fulfills requirements. 'association_FUN' ",
+                      "threw a following error:\n",  cond),
               call. = FALSE)
       }
       )


### PR DESCRIPTION
Update error message: Now user gets the error message of 'association_FUN'. For example, I got an error that I must use na.rm =TRUE (while running with debug mode) --> internal error might be useful sometimes (at least at this point, when user uses his / her own function)