### PR TITLE
mergeSEs: simplify

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.7.6
+Version: 1.7.7
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut"),
              email = "felix.gm.ernst@outlook.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.7.5
+Version: 1.7.6
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut"),
              email = "felix.gm.ernst@outlook.com",

--- a/NEWS
+++ b/NEWS
@@ -66,4 +66,8 @@ Changes in version 1.7.x
 + mergeSEs: option for merging multiple assays
 + calculateUnifrac: option for specifying the tree from TreeSE
 + transformCounts: utilize vegan package
-
++ calculateUnifrac: subset tree based on data
++ agglomerateByRank: take into account multiple trees
++ loadFromBiom: name columns of rowData based on prefixes
++ Deprecate transformSamples and transformFeatures
++ mergeSEs: faster tree merging

--- a/R/mergeSEs.R
+++ b/R/mergeSEs.R
@@ -306,7 +306,8 @@ setMethod("right_join", signature = c(x = "ANY"),
 .merge_SEs <- function(x, class, join, assay_name, 
                       missing_values, collapse_samples, verbose){
     # Add rowData info to rownames
-    x <- lapply(x, FUN = .add_rowdata_to_rownames)
+    rownames_name <- "rownames_that_will_be_used_to_adjust_names"
+    x <- lapply(x, FUN = .add_rowdata_to_rownames, colname = rownames_name)
     # Take first element and remove it from the list
     tse <- x[[1]]
     x[[1]] <- NULL
@@ -387,7 +388,6 @@ setMethod("right_join", signature = c(x = "ANY"),
         tse <- .check_and_add_refSeqs(tse, refSeqs, verbose)
     }
     # Adjust rownames
-    rownames_name <- "rownames_that_will_be_used_to_adjust_names"
     rownames(tse) <- rowData(tse)[[rownames_name]]
     rowData(tse)[[rownames_name]] <- NULL
     return(tse)
@@ -399,10 +399,9 @@ setMethod("right_join", signature = c(x = "ANY"),
 
 # Input: (Tree)SE
 # Output: (Tree)SE with rownames that include all taxonomy information
-.add_rowdata_to_rownames <- function(x){
+.add_rowdata_to_rownames <- function(x, colname){
     # Add rownames to rowData
-    rownames_name <- "rownames_that_will_be_used_to_adjust_names"
-    rowData(x)[[rownames_name]] <- rownames(x)
+    rowData(x)[[colname]] <- rownames(x)
     # Get rowData
     rd <- rowData(x)
     # Get taxonomy_info

--- a/R/mergeSEs.R
+++ b/R/mergeSEs.R
@@ -843,15 +843,14 @@ setMethod("right_join", signature = c(x = "ANY"),
         names2 <- colnames(tse2)
     }
     # Get unique values
-    names <- make.unique(c(names1, names2))
-    names1 <- names[1:length(names1)]
-    names2 <- names[(length(names1)+1):length(names)]
+    while(any(names1 %in% paste0(names2, ".", iteration))){
+        iterations <- iteration + 1
+    }
+    names2 <- paste0(names2, ".", iteration)
     # Assign names back
     if( MARGIN == "row" ){
-        rownames(tse1) <- names1
         rownames(tse2) <- names2
     } else{
-        colnames(tse1) <- names1
         colnames(tse2) <- names2
     }
     return(tse2)

--- a/R/mergeSEs.R
+++ b/R/mergeSEs.R
@@ -543,7 +543,7 @@ setMethod("right_join", signature = c(x = "ANY"),
     }
     
     # Order the data to match created TreeSE
-    links <- links[match(links$names, rownames(tse)), ]
+    links <- links[rownames(tse), ]
     trees <- trees[unique(links$whichTree)]
     
     # Create a LinkDataFrame based on the link data

--- a/R/mergeSEs.R
+++ b/R/mergeSEs.R
@@ -481,7 +481,7 @@ setMethod("right_join", signature = c(x = "ANY"),
         temp_seqs <- do.call(c, temp_seqs)
         # Get only those taxa that are included in TreeSE
         temp_seqs <- temp_seqs[ match(rownames(tse), names(temp_seqs)), ]
-        # Add combined ssequences into a list
+        # Add combined sequences into a list
         result_list <- c(result_list, temp_seqs)
     }
     # Create a DNAStrinSetList if there are more than one element
@@ -842,20 +842,16 @@ setMethod("right_join", signature = c(x = "ANY"),
         names1 <- colnames(tse1)
         names2 <- colnames(tse2)
     }
-    # Get indices of those sample names that match
-    ind <-  names2 %in% names1
-    # Get duplicated sample names
-    duplicated_names <-  names2[ind]
-    if( length(duplicated_names) > 0 ) {
-        # Add the number of object to duplicated sample names
-        duplicated_names <- paste0(duplicated_names, "_", iteration)
-        # Add new sample names to the tse object
-        names2[ind] <- duplicated_names
-    }
+    # Get unique values
+    names <- make.unique(c(names1, names2))
+    names1 <- names[1:length(names1)]
+    names2 <- names[(length(names1)+1):length(names)]
     # Assign names back
     if( MARGIN == "row" ){
+        rownames(tse1) <- names1
         rownames(tse2) <- names2
     } else{
+        colnames(tse1) <- names1
         colnames(tse2) <- names2
     }
     return(tse2)

--- a/R/mergeSEs.R
+++ b/R/mergeSEs.R
@@ -366,10 +366,10 @@ setMethod("right_join", signature = c(x = "ANY"),
 
             # Modify names if specified
             if( !collapse_samples ){
-                temp <- .get_unique_names(tse, temp, "col", i+1)
+                temp <- .get_unique_names(tse, temp, "col")
             }
             if( !collapse_features ){
-                temp <- .get_unique_names(tse, temp, "row", i+1)
+                temp <- .get_unique_names(tse, temp, "row")
             }
             # Merge data
             args <- .merge_SummarizedExperiments(
@@ -833,7 +833,7 @@ setMethod("right_join", signature = c(x = "ANY"),
 
 # Input: TreeSEs and MARGIN
 # Output: One TreeSE with unique sample names compared to other TreeSE
-.get_unique_names <- function(tse1, tse2, MARGIN, iteration){
+.get_unique_names <- function(tse1, tse2, MARGIN, suffix=2){
     # Based on MARGIN, get right names
     if( MARGIN == "row" ){
         names1 <- rownames(tse1)
@@ -842,16 +842,22 @@ setMethod("right_join", signature = c(x = "ANY"),
         names1 <- colnames(tse1)
         names2 <- colnames(tse2)
     }
-    # Get unique values
-    while(any(names1 %in% paste0(names2, ".", iteration))){
-        iterations <- iteration + 1
-    }
-    names2 <- paste0(names2, ".", iteration)
-    # Assign names back
-    if( MARGIN == "row" ){
-        rownames(tse2) <- names2
-    } else{
-        colnames(tse2) <- names2
+    # If there are duplicated names
+    if( any(names2 %in% names1) ){
+        # Get duplicated names
+        ind <- names2 %in% names1
+        temp_names2 <- names2[ind]
+        # Get unique suffix
+        while( any(paste0(names2, ".", suffix) %in% names1) ){
+            suffix <- suffix + 1
+        }
+        temp_names2 <- paste0(temp_names2, ".", suffix)
+        # Assign names back
+        if( MARGIN == "row" ){
+            rownames(tse2)[ind] <- temp_names2
+        } else{
+            colnames(tse2)[ind] <- temp_names2
+        }
     }
     return(tse2)
 }

--- a/man/mergeSEs.Rd
+++ b/man/mergeSEs.Rd
@@ -23,6 +23,7 @@ mergeSEs(x, ...)
   join = "full",
   missing_values = NA,
   collapse_samples = FALSE,
+  collapse_features = TRUE,
   verbose = TRUE,
   ...
 )
@@ -66,6 +67,15 @@ of missing values. (By default: \code{missing_values = NA})}
 
 \item{collapse_samples}{A boolean value for selecting whether to collapse identically
 named samples to one. (By default: \code{collapse_samples = FALSE})}
+
+\item{collapse_features}{A boolean value for selecting whether to collapse identically
+named features to one. Since all taxonomy information is taken into account,
+this concerns rownames-level (usually strain level) comparison. Often
+OTU or ASV level is just an arbitrary number series from sequencing machine
+meaning that the OTU information is not comparable between studies. With this
+option, it is possible to specify whether these strains are combined if their
+taxonomy information along with OTU number matches.
+(By default: \code{collapse_features = TRUE})}
 
 \item{verbose}{A single boolean value to choose whether to show messages.
 (By default: \code{verbose = TRUE})}

--- a/tests/testthat/test-2mergeSEs.R
+++ b/tests/testthat/test-2mergeSEs.R
@@ -331,13 +331,13 @@ test_that("mergeSEs", {
     tse_test <- mergeSEs(x = list(tse[1:28, 1:3], tse[23, 1:5], tse[1, 1:10]),
                          join = "full")
     expect_equal( dim(tse_test), c(28, 18))
-    expect_true( (all( c( paste0(rep(colnames(tse[, 1:3]), each=3), c("", "_2", "_3")), 
-                         paste0(rep(colnames(tse[, 4:5]), each=2), c("", "_3")), 
+    expect_true( (all( c( paste0(rep(colnames(tse[, 1:3]), each=3), c("", ".2", ".3")), 
+                         paste0(rep(colnames(tse[, 4:5]), each=2), c("", ".3")), 
                          colnames(tse[, 6:10]) ) %in% 
                           colnames(tse_test) ) &&
                      all( colnames(tse_test) %in% 
-                     c( paste0(rep(colnames(tse[, 1:3]), each=3), c("", "_2", "_3")), 
-                        paste0(rep(colnames(tse[, 4:5]), each=2), c("", "_3")), 
+                     c( paste0(rep(colnames(tse[, 1:3]), each=3), c("", ".2", ".3")), 
+                        paste0(rep(colnames(tse[, 4:5]), each=2), c("", ".3")), 
                         colnames(tse[, 6:10]) ) ) )
                  )
     # Test that tree is added after agglomeration


### PR DESCRIPTION
Merging trees took too long when optimal solution was the function tried to found an optimal solution and the function ended up trying all the combinations

I simplified the function:

1. rowTrees are ordered based on the number of row that they include
2. Duplicated rows are removed from the rowLinks
3. --> Each row of TreeSE is present just once
4. The function includes those trees that are still present in links
5. --> If dataset includes a tree that have all the rows, only one tree is included

The disadvantage of this solution compared to previous one is that it might be that the optimal solution is not found
--> the optimal solution might be tree1 and tree3, but the function takes tree1, tree2 and tree3

- tree1 is the largest tree, tree3 the smallest
- tree3 includes certain rows that are not present in tree2