### PR TITLE
agglomerareByRank: multiple rowTrees

### DIFF
--- a/R/agglomerate.R
+++ b/R/agglomerate.R
@@ -303,14 +303,14 @@ setMethod("agglomerateByRank", signature = c(x = "TreeSummarizedExperiment"),
 .order_based_on_trees <- function(x){
     # Get rowlinks and unique trees
     links <- DataFrame(rowLinks(x))
-    uniq_trees <- unique(links$whichTree)
+    uniq_trees <- sort(unique(links$whichTree))
     # Get row index to the data
     links$row_i <- seq_len(nrow(x))
     # Calculate, how many rows each tree has, and add it to data
     freq <- as.data.frame(table(links$whichTree))
     links <- merge(links, freq, all.x = TRUE, all.y = FALSE,
                    by.x = "whichTree", by.y = "Var1")
-    # FActorize the names of trees
+    # Factorize the names of trees
     links$whichTree <- factor(links$whichTree, level = uniq_trees)
     # Order the data back to its original order based on row indices
     links <- links[order(links$row_i), ]

--- a/R/agglomerate.R
+++ b/R/agglomerate.R
@@ -311,7 +311,7 @@ setMethod("agglomerateByRank", signature = c(x = "TreeSummarizedExperiment"),
     links <- merge(links, freq, all.x = TRUE, all.y = FALSE,
                    by.x = "whichTree", by.y = "Var1")
     # Factorize the names of trees
-    links$whichTree <- factor(links$whichTree, level = uniq_trees)
+    links$whichTree <- factor(links$whichTree, levels = uniq_trees)
     # Order the data back to its original order based on row indices
     links <- links[order(links$row_i), ]
     # Get the order based on size of tree and name

--- a/R/agglomerate.R
+++ b/R/agglomerate.R
@@ -233,18 +233,34 @@ setMethod("agglomerateByRank", signature = c(x = "SingleCellExperiment"),
 #' @rdname agglomerate-methods
 #' @export
 setMethod("agglomerateByRank", signature = c(x = "TreeSummarizedExperiment"),
-    function(x, ..., agglomerateTree = FALSE){
-        # input check
-        if(!.is_a_bool(agglomerateTree)){
-            stop("'agglomerateTree' must be TRUE or FALSE.", call. = FALSE)
-        }
-        #
-        x <- callNextMethod(x, ...)
-        if(agglomerateTree){
-            x <- addTaxonomyTree(x)
-        }
-        x
-    }
+          function(x, ..., agglomerateTree = FALSE, combine_trees = TRUE){
+              # input check
+              if(!.is_a_bool(agglomerateTree)){
+                  stop("'agglomerateTree' must be TRUE or FALSE.", call. = FALSE)
+              }
+              # If there are multipe rowTrees, it might be that multiple
+              # trees are preserved after agglomeration even though the dataset
+              # could be presented with one tree. --> order the data so that
+              # the taxa are searched from one tree first.
+              if( length(x@rowTree) > 1 ){
+                  x <- .order_based_on_trees(x)
+              }
+              # Agglomerate data
+              x <- callNextMethod(x, ...)
+              # Agglomerate also tree, if the data includes only one
+              # rowTree --> otherwise it is not possible to agglomerate
+              # since all rownames are not found from individual tree.
+              if(agglomerateTree){
+                  if( length(x@rowTree) > 1 ){
+                      warning("The dataset includes multiple tree after ",
+                              "agglomeration. Agglomeration of tree is not ",
+                              "possible.", call. = FALSE)
+                  } else{
+                      x <- addTaxonomyTree(x)
+                  }
+              }
+              x
+          }
 )
 
 ################################ HELP FUNCTIONS ################################
@@ -279,5 +295,19 @@ setMethod("agglomerateByRank", signature = c(x = "TreeSummarizedExperiment"),
         # Assign it back to SE
         rowData(x) <- rd
     }
+    return(x)
+}
+
+# Order the data so that taxa from tree1 comes first, then taxa
+# from tree2...
+.order_based_on_trees <- function(x){
+    # Get rowlinks and unique trees
+    links <- DataFrame(rowLinks(x))
+    uniq_trees <- sort(unique(links$whichTree))
+    # Get the order of data based on unique trees
+    links$whichTree <- factor(links$whichTree, level = uniq_trees)
+    order <- order(links$whichTree)
+    # Order the data
+    x <- x[order, ]
     return(x)
 }

--- a/R/agglomerate.R
+++ b/R/agglomerate.R
@@ -303,9 +303,18 @@ setMethod("agglomerateByRank", signature = c(x = "TreeSummarizedExperiment"),
 .order_based_on_trees <- function(x){
     # Get rowlinks and unique trees
     links <- DataFrame(rowLinks(x))
-    uniq_trees <- sort(unique(links$whichTree))
-    # Get the order of data based on unique trees
+    uniq_trees <- unique(links$whichTree)
+    # Get row index to the data
+    links$row_i <- seq_len(nrow(x))
+    # Calculate, how many rows each tree has, and add it to data
+    freq <- as.data.frame(table(links$whichTree))
+    links <- merge(links, freq, all.x = TRUE, all.y = FALSE,
+                   by.x = "whichTree", by.y = "Var1")
+    # FActorize the names of trees
     links$whichTree <- factor(links$whichTree, level = uniq_trees)
+    # Order the data back to its original order based on row indices
+    links <- links[order(links$row_i), ]
+    # Get the order based on size of tree and name
     order <- order(links$whichTree)
     # Order the data
     x <- x[order, ]

--- a/R/agglomerate.R
+++ b/R/agglomerate.R
@@ -233,7 +233,7 @@ setMethod("agglomerateByRank", signature = c(x = "SingleCellExperiment"),
 #' @rdname agglomerate-methods
 #' @export
 setMethod("agglomerateByRank", signature = c(x = "TreeSummarizedExperiment"),
-          function(x, ..., agglomerateTree = FALSE, combine_trees = TRUE){
+          function(x, ..., agglomerateTree = FALSE){
               # input check
               if(!.is_a_bool(agglomerateTree)){
                   stop("'agglomerateTree' must be TRUE or FALSE.", call. = FALSE)

--- a/man/agglomerate-methods.Rd
+++ b/man/agglomerate-methods.Rd
@@ -19,7 +19,7 @@
 
 \S4method{agglomerateByRank}{SingleCellExperiment}(x, ..., altexp = NULL, strip_altexp = TRUE)
 
-\S4method{agglomerateByRank}{TreeSummarizedExperiment}(x, ..., agglomerateTree = FALSE)
+\S4method{agglomerateByRank}{TreeSummarizedExperiment}(x, ..., agglomerateTree = FALSE, combine_trees = TRUE)
 }
 \arguments{
 \item{x}{a

--- a/man/agglomerate-methods.Rd
+++ b/man/agglomerate-methods.Rd
@@ -19,7 +19,7 @@
 
 \S4method{agglomerateByRank}{SingleCellExperiment}(x, ..., altexp = NULL, strip_altexp = TRUE)
 
-\S4method{agglomerateByRank}{TreeSummarizedExperiment}(x, ..., agglomerateTree = FALSE, combine_trees = TRUE)
+\S4method{agglomerateByRank}{TreeSummarizedExperiment}(x, ..., agglomerateTree = FALSE)
 }
 \arguments{
 \item{x}{a


### PR DESCRIPTION
agglomerateByRank:
- Data includes multiple trees, because trees are different in ASV level
- After agglomeration (e.g. to phylum level) data could be presented with one tree, because all trees include equal Phylum level information
- However, agglomerateByRank does not take this into account -->  first instance of Phylum 1, Phylum 2 is preserved...
- It might be that these taxa have different rowTrees in rowLink
- --> multiple rowTrees are preserved


FIX:

- Data is first ordered so that all taxa of tree 1 comes first, then taxa from tree 2...
- --> In the agglomeration, taxa from the tree 1 are preserved and all others are discarded (if tree 1 includes all taxa)