### PR TITLE
Unifrac fix

### DIFF
--- a/R/calculateUnifrac.R
+++ b/R/calculateUnifrac.R
@@ -22,7 +22,7 @@
 #'   to the same type of features (aka. microorganisms).
 #'   
 #' @param nodeLab if \code{x} is a matrix, 
-#'   a \code{character} vector specifying links between rows/columns and nodes of \code{tree}.
+#'   a \code{character} vector specifying links between rows/columns and tips of \code{tree}.
 #'   The length must equal the number of rows/columns of \code{x}. Furthermore, all the 
 #'   node labs must be present in \code{tree}.
 #'
@@ -238,13 +238,13 @@ runUnifrac <- function(x, tree, weighted = FALSE, normalized = TRUE,
     # rows and tree labels
     if( !(is.null(nodeLab) ||
         (is.character(nodeLab) && length(nodeLab) == nrow(x) &&
-        all(nodeLab[ !is.na(nodeLab) ] %in% c(tree$tip.label, tree$node.label)))) ){
+        all(nodeLab[ !is.na(nodeLab) ] %in% c(tree$tip.label)))) ){
         stop("'nodeLab' must be NULL or character specifying links between ",
              "abundance table and tree labels.", call. = FALSE)
     }
     # check that matrix and tree are compatible
     if( is.null(nodeLab) && 
-        !all(rownames(x) %in% c(tree$tip.label, tree$node.label)) ) {
+        !all(rownames(x) %in% c(tree$tip.label)) ) {
         stop("Incompatible tree and abundance table! Please try to provide ",
              "'nodeLab'.", call. = FALSE)
     }
@@ -258,6 +258,13 @@ runUnifrac <- function(x, tree, weighted = FALSE, normalized = TRUE,
     x <- .merge_assay_by_rows(x, nodeLab, ...)
     # Modify tree
     tree <- .norm_tree_to_be_rooted(tree, rownames(x))
+    # Remove those tips that are not present in the data
+    if( !tree$tip.label %in% rownames(x) ){
+        tree <- ape::drop.tip(
+            tree, tree$tip.label[!tree$tip.label %in% rownames(x)])
+        warning("The tree is pruned so that tips that cannot be found from ", 
+                "the abundance matrix are removed.", call. = FALSE)
+    }
     #
     old <- getAutoBPPARAM()
     setAutoBPPARAM(BPPARAM)
@@ -279,10 +286,6 @@ runUnifrac <- function(x, tree, weighted = FALSE, normalized = TRUE,
     # Begin by building the edge descendants matrix (edge-by-sample)
     # `edge_array`
     #
-    
-    # Remove those tips that are not present in the data
-    tree <- ape::drop.tip(
-        tree, tree$tip.label[!tree$tip.label %in% rownames(x)])
     # Create a list of descendants, starting from the first internal node (root)
     ntip <- length(tree$tip.label)
     # Create a matrix that maps each internal node to its 2 descendants

--- a/R/calculateUnifrac.R
+++ b/R/calculateUnifrac.R
@@ -259,7 +259,7 @@ runUnifrac <- function(x, tree, weighted = FALSE, normalized = TRUE,
     # Modify tree
     tree <- .norm_tree_to_be_rooted(tree, rownames(x))
     # Remove those tips that are not present in the data
-    if( !tree$tip.label %in% rownames(x) ){
+    if( any(!tree$tip.label %in% rownames(x)) ){
         tree <- ape::drop.tip(
             tree, tree$tip.label[!tree$tip.label %in% rownames(x)])
         warning("The tree is pruned so that tips that cannot be found from ", 

--- a/R/calculateUnifrac.R
+++ b/R/calculateUnifrac.R
@@ -279,6 +279,10 @@ runUnifrac <- function(x, tree, weighted = FALSE, normalized = TRUE,
     # Begin by building the edge descendants matrix (edge-by-sample)
     # `edge_array`
     #
+    
+    # Remove those tips that are not present in the data
+    tree <- ape::drop.tip(
+        tree, tree$tip.label[!tree$tip.label %in% rownames(x)])
     # Create a list of descendants, starting from the first internal node (root)
     ntip <- length(tree$tip.label)
     # Create a matrix that maps each internal node to its 2 descendants

--- a/man/calculateUnifrac.Rd
+++ b/man/calculateUnifrac.Rd
@@ -92,7 +92,7 @@ is Unifrac distance calculated based on rows (FALSE) or columns (TRUE).
 (By default: \code{transposed = FALSE})}
 
 \item{nodeLab}{if \code{x} is a matrix,
-a \code{character} vector specifying links between rows/columns and nodes of \code{tree}.
+a \code{character} vector specifying links between rows/columns and tips of \code{tree}.
 The length must equal the number of rows/columns of \code{x}. Furthermore, all the
 node labs must be present in \code{tree}.}
 }


### PR DESCRIPTION
Unifrac calculation ended up to an error when the tree contained more tips than there are rows.

In this [paper](https://journals.asm.org/doi/10.1128/AEM.71.12.8228-8235.2005?url_ver=Z39.88-2003&rfr_id=ori:rid:crossref.org&rfr_dat=cr_pub%20%200pubmed), they removed those tips that were not present in samples --> Now the same thing is done in our function