### PR TITLE
CLR: remove unnecessary warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.6.0
+Version: 1.7.0
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut"),
              email = "felix.gm.ernst@outlook.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.5.17
+Version: 1.6.0
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut"),
              email = "felix.gm.ernst@outlook.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.7.7
+Version: 1.7.8
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut"),
              email = "felix.gm.ernst@outlook.com",

--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -435,16 +435,6 @@ setMethod("relAbundanceCounts", signature = c(x = "SummarizedExperiment"),
     # Adjust method if mia-specific alias was used
     method <- ifelse(method == "relabundance", "total", method)
     method <- ifelse(method == "z", "standardize", method)
-    # If method is CLR give warning if samples do not up to constant
-    # (CLR is accurate only when samples sum-up to fixed constant, like 1)
-    colsums <- colSums2(mat, na.rm = TRUE)
-    if( method %in% c("clr", "rclr") &&
-        abs(max(colsums) - min(colsums)) > 0.01 ){
-        warning("All the total abundances of samples do not sum-up ",
-                "to a fixed constant.\nPlease consider to apply, e.g., ",
-                "relative transformation in prior to CLR transformation.",
-                call. = FALSE)
-    }
     # If method is ALR, vegan drops one column/sample, because it is used
     # as a reference. To work with TreeSE, reference sample must be added back.
     # Get the original order of samples/features

--- a/tests/testthat/test-5transformCounts.R
+++ b/tests/testthat/test-5transformCounts.R
@@ -187,7 +187,18 @@ test_that("transformCounts", {
         tse <- transformCounts(
             tse, assay_name = "counts", method = "clr", pseudocount = 1)
         tse <- transformCounts(tse, assay_name = "counts", method = "rclr")
-
+        
+        # Test that CLR with counts equal to CLR with relabundance
+        assay(tse, "pseudo") <- assay(tse, "counts") + 1
+        tse <- transformCounts(
+            tse, assay_name = "counts", method = "relabundance")
+        tse <- transformCounts(
+            tse, assay_name = "pseudo", method = "clr", name = "clr1")
+        tse <- transformCounts(
+            tse, assay_name = "counts", method = "clr", name = "clr2",
+            pseudocount =1)
+        expect_equal(assay(tse, "clr1"), assay(tse, "clr2"),
+                     check.attributes = FALSE)
         ############################# NAMES ####################################
         # Tests that samples have correct names
         expect_equal(colnames(assays(transformCounts(tse, assay_name = "relabundance",

--- a/tests/testthat/test-5transformCounts.R
+++ b/tests/testthat/test-5transformCounts.R
@@ -141,16 +141,12 @@ test_that("transformCounts", {
         expect_equal(mat, mat_comp, check.attributes = FALSE)
         
         # Expect that error occurs
-        expect_warning(
             expect_error(mia::transformCounts(tse, method = "clr"))
-        )
         # Expect that error does not occur
-        expect_warning(mia::transformCounts(tse, method = "rclr")) 
+        tse <- mia::transformCounts(tse, method = "rclr")
         
         # Tests transformCounts, tries to calculate clr. Should be an error, because of zeros.
-        expect_warning(
         expect_error(mia::transformCounts(tse, method = "clr"))
-        )
         
         # Tests that clr robust gives values that are approximately same if only 
         # one value per sample are changed to zero
@@ -174,26 +170,23 @@ test_that("transformCounts", {
         
         tse <- transformCounts(tse, method = "relabundance")
         # Expect error when counts and zeroes
-        expect_warning(
-        expect_error(transformCounts(tse, assay_name = "counts", 
-                                      method = "clr"))
-        )
+        expect_error(
+            transformCounts(tse, assay_name = "counts", method = "clr"))
         # Expect error warning when zeroes
         tse <- transformCounts(tse, method = "relabundance")
         expect_error(transformCounts(tse, assay_name = "relabundance", 
                                      method = "clr") ) 
         # Expect no warning when pseudocount is added, colSums are over 1
-        expect_warning(transformCounts(tse, assay_name = "relabundance", 
-                                       method = "clr", pseudocount = 1), 
-                       regexp = NA)
+        tse <- transformCounts(
+            tse, assay_name = "relabundance", method = "clr", pseudocount = 1)
         # Expect no warning when pseudocount is added, colSums are 1
         tse <- transformCounts(tse, method = "relabundance", pseudocount = 1, 
                                 name = "relabund2")
         expect_error(transformCounts(tse, assay_name = "relabund2", method = "clr"))
         # Expect warning when colSums are not equal
-        expect_warning(transformCounts(tse, assay_name = "counts", 
-                                       method = "clr", pseudocount = 1))
-        expect_warning(transformCounts(tse, assay_name = "counts", method = "rclr"))
+        tse <- transformCounts(
+            tse, assay_name = "counts", method = "clr", pseudocount = 1)
+        tse <- transformCounts(tse, assay_name = "counts", method = "rclr")
 
         ############################# NAMES ####################################
         # Tests that samples have correct names


### PR DESCRIPTION
There was unnecessary warning that said that CLR transformation expect samples to sum to fixed constant. That is not true; in fact that does not affect the result. I removed the warning