### PR TITLE
loadFromMetaphlan fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.9.2
+Version: 1.9.3
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut"),
              email = "felix.gm.ernst@outlook.com",

--- a/NEWS
+++ b/NEWS
@@ -74,3 +74,6 @@ Changes in version 1.7.x
 + Deprecate transformSamples, *Features, relabundance, ZTransform, relAbundanceCounts
 + mergeSEs: faster tree merging
 + Faith's index: fix bug that occurred when only one taxon is present
+
+Changes in version 1.9.x
++ loadFromMetaphlan: Bugfix, not all files include ID column.


### PR DESCRIPTION
Fixes:

1. Some metaphlan files do not have ID column. Those ones have only clade_name column going to rowData (This "first two columns" did not work)

2. read.table changed column names if number was the first character. It does not do that anymore.



