### PR TITLE
Streamline RDA significance attribute

### DIFF
--- a/R/runCCA.R
+++ b/R/runCCA.R
@@ -84,7 +84,7 @@
 #' plotReducedDim(GlobalPatterns,"CCA", colour_by = "SampleType")
 #' 
 #' # Fetch significance results
-#' attr(reducedDim(GlobalPatterns, "CCA"), "significance")$summary
+#' attr(reducedDim(GlobalPatterns, "CCA"), "significance")
 #'
 #' GlobalPatterns <- runRDA(GlobalPatterns, data ~ SampleType)
 #' plotReducedDim(GlobalPatterns,"CCA", colour_by = "SampleType")
@@ -354,25 +354,21 @@ setMethod("runCCA", "SingleCellExperiment",
     # Create a table from the results
     # PERMANOVAs
     table_model <- as.data.frame(permanova_model)
-    table <- as.data.frame(permanova)
+    permanova_tab <- as.data.frame(permanova)
     # Take only model results
-    table <- rbind(table_model[1, ], table)
+    permanova_tab <- rbind(table_model[1, ], permanova_tab)
+    # Add info about total variance
+    permanova_tab[ , "Total variance"] <- permanova_tab["Model", "SumOfSqs"] + permanova_tab["Residual", "SumOfSqs"]
+    # Add info about explained variance
+    permanova_tab[ , "Explained variance"] <- permanova_tab[ , "SumOfSqs"] / permanova_tab[ , "Total variance"]
     # Take homogeneity results of the different groups
     homogeneity_tab <- lapply(homogeneity, function(x) as.data.frame(x$anova)[1, ])
     homogeneity_tab <- do.call(rbind, homogeneity_tab)
-    # Adjust colnames of tables, add info
-    colnames(table) <- paste0(colnames(table), " (PERMANOVA)")
-    colnames(homogeneity_tab) <- paste0(colnames(homogeneity_tab), " (homogeneity)")
-    # Combine and adjust rownames
-    table <- merge(table, homogeneity_tab, by=0, all.x = TRUE)
-    rownames(table) <- table[["Row.names"]]
-    table[["Row.names"]] <- NULL
     
     # Add the results to original RDA object
     res <- list(
-        summary = table,
-        permanova = list(model = permanova_model, variables = permanova),
-        homogeneity = homogeneity)
+        permanova = permanova_tab,
+        homogeneity = homogeneity_tab)
     return(res)
 }
 


### PR DESCRIPTION
Hi! I tried to streamline `attr(rda, "significance")` so that output is easier to interpret and use. Also added Total and Explained variance columns to permanova table.

For example:

```
library(mia)

# Load data
data(enterotype, package="mia")
tse <- enterotype

# Apply relative transform
tse <- transformCounts(tse, method = "relabundance")

# # Perform RDA
mae <- runRDA(tse,
              assay.type = "relabundance",
              formula = assay ~ ClinicalStatus + Gender + Age,
              distance = "bray",
              na.action = na.exclude)

rda_tse <- mae[["subset"]]
rdrda <- reducedDim(rda_tse, "RDA")

attr(rdrda, "significance")

# $permanova
#
#                Df SumOfSqs     F Pr(>F) Total variance Explained variance
# Model           6   1.1157 1.940  0.040          3.991            0.27952
# ClinicalStatus  4   0.5837 1.522  0.129          3.991            0.14625
# Gender          1   0.1679 1.751  0.100          3.991            0.04206
# Age             1   0.5245 5.471  0.001          3.991            0.13140
# Residual       30   2.8757    NA     NA          3.991            0.72048
#
# $homogeneity
#
#                Df  Sum Sq Mean Sq F value    Pr(>F)
# ClinicalStatus  4 0.25108 0.06277  2.7440 0.0442777
# Gender          1 0.01032 0.01032  0.4158 0.5229990
# Age            29 0.32723 0.01128 17.0255 0.0003692
```