### PR TITLE
Update transformAssay with pseudocount TRUE/FALSE option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .Rhistory
 .RData
 .Ruserdata
+.DS_Store
 *.Rproj
 /doc/
 /Meta/

--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -474,13 +474,16 @@ setMethod("relAbundanceCounts", signature = c(x = "SummarizedExperiment"),
 ####################################.calc_log###################################
 # This function applies log transformation to abundance table.
 .calc_log <- function(mat, method, ...){
-    # If abundance table contains zeros, gives an error, because it is not
-    # possible to calculate log from zeros. If there is no zeros, calculates log.
-    if (any(mat <= 0, na.rm = TRUE)) {
-        stop("Abundance table contains zero or negative values and ",
-            method, " transformation is being applied without pseudocount.\n",
-            "Pseudocount must be set to TRUE.",
-            call. = FALSE)
+    # If abundance table contains zeros or negative values, gives an error, because
+    # it is not possible to calculate log from zeros. Otherwise, calculates log.
+    if ( any(mat < 0, na.rm = TRUE) ){
+        stop("The assay contains negative values and ", method,
+             " transformation is being applied without pseudocount.",
+            "`pseudocount` must be specified manually.", call. = FALSE)
+    } else if ( any(mat == 0, na.rm = TRUE) ){
+        stop("The assay contains zeroes and ", method,
+             " transformation is being applied without pseudocount.",
+             "`pseudocount` must be set to TRUE.", call. = FALSE)
     }
     # Calculate log2 or log10 abundances
     if(method == "log2"){
@@ -561,12 +564,12 @@ setMethod("relAbundanceCounts", signature = c(x = "SummarizedExperiment"),
     }
     # Give warning if pseudocount should not be added
     # Case 1: only positive values
-    if( all(mat>0) ){
+    if( pseudocount != 0 && all(mat>0) ){
         warning("The assay contains only positive values. ",
                 "Applying a pseudocount is not necessary.", call. = FALSE)
     }
     # Case 2: some negative values
-    if( any(mat<0) ){
+    if( pseudocount != 0 && any(mat<0) ){
         warning("The assay contains some negative values. ",
                 "Applying a pseudocount may produce meaningless data.", call. = FALSE)
     }

--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -290,7 +290,10 @@ setMethod("transformAssay", signature = c(x = "SummarizedExperiment"),
         
         # Apply pseudocount, if it is not 0
         assay <- .apply_pseudocount(assay, pseudocount)
-	
+        # Store pseudocount value and set attr equal to NULL
+        pseudocount <- attr(assay, "pseudocount")
+        attr(assay, "pseudocount") <- NULL
+        
         # Calls help function that does the transformation
         # Help function is different for mia and vegan transformations
         if( method %in% c("log10", "log2") ){
@@ -569,5 +572,7 @@ setMethod("relAbundanceCounts", signature = c(x = "SummarizedExperiment"),
     }
     # Add pseudocount
     mat <- mat + pseudocount
+    # Set attr equal to pseudocount
+    attr(mat, "pseudocount") <- pseudocount
     return(mat)
 }

--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -566,7 +566,7 @@ setMethod("relAbundanceCounts", signature = c(x = "SummarizedExperiment"),
     # Case 1: only positive values
     if( pseudocount != 0 && all(mat>0) ){
         warning("The assay contains only positive values. ",
-                "Applying a pseudocount is not necessary.", call. = FALSE)
+                "Applying a pseudocount may be unnecessary.", call. = FALSE)
     }
     # Case 2: some negative values
     if( pseudocount != 0 && any(mat<0) ){

--- a/man/transformAssay.Rd
+++ b/man/transformAssay.Rd
@@ -30,7 +30,7 @@ transformSamples(
   method = c("alr", "chi.square", "clr", "frequency", "hellinger", "log", "log10",
     "log2", "normalize", "pa", "rank", "rclr", "relabundance", "rrank", "total"),
   name = method,
-  pseudocount = 0,
+  pseudocount = FALSE,
   ...
 )
 
@@ -43,7 +43,7 @@ transformAssay(
     "standardize", "total", "z"),
   MARGIN = "samples",
   name = method,
-  pseudocount = 0,
+  pseudocount = FALSE,
   ...
 )
 
@@ -56,7 +56,7 @@ transformAssay(
     "standardize", "total", "z"),
   MARGIN = "samples",
   name = method,
-  pseudocount = 0,
+  pseudocount = FALSE,
   ...
 )
 
@@ -67,7 +67,7 @@ transformFeatures(
   method = c("frequency", "log", "log10", "log2", "max", "pa", "range", "standardize",
     "z"),
   name = method,
-  pseudocount = 0,
+  pseudocount = FALSE,
   ...
 )
 
@@ -78,7 +78,7 @@ transformFeatures(
   method = c("frequency", "log", "log10", "log2", "max", "pa", "range", "standardize",
     "z"),
   name = method,
-  pseudocount = 0,
+  pseudocount = FALSE,
   ...
 )
 
@@ -117,11 +117,9 @@ reference sample's column in returned assay when calculating alr.
 (default: \code{ref_vals = NA})}
 }}
 
-\item{pseudocount}{NULL or numeric value deciding whether pseudocount is
-added. The numeric value specifies the value of pseudocount.
-Recommended default choices for counts and relative abundance assay
-\code{pseudocount = 1} and \code{pseudocount = min(assay[assay>0])}, respectively.
-(By default: \code{pseudocount = 0})}
+\item{pseudocount}{TRUE or FALSE, should the minimum value of \code{assay.type}
+be added to assay values. Alternatively, a numeric value specifying the value
+to be added. (default: \code{pseudocount = FALSE})}
 
 \item{MARGIN}{A single character value for specifying whether the
 transformation is applied sample (column) or feature (row) wise.
@@ -220,12 +218,9 @@ tse <- transformAssay(tse, method = "relabundance")
 # The target of transformation can be specified with "assay.type"
 # Pseudocount can be added by specifying 'pseudocount'.
 
-# Get pseudocount; here smallest positive value
-mat <- assay(tse, "relabundance") 
-pseudonumber <- min(mat[mat>0])
-# Perform CLR
+# Perform CLR with smallest positive value as pseudocount
 tse <- transformAssay(tse, assay.type = "relabundance", method = "clr", 
-                     pseudocount = pseudonumber
+                     pseudocount = TRUE
                      )
                       
 head(assay(tse, "clr"))

--- a/tests/testthat/test-5transformCounts.R
+++ b/tests/testthat/test-5transformCounts.R
@@ -36,10 +36,7 @@ test_that("transformAssay", {
                                    rowData = df)
         expect_error(transformAssay(se, name = FALSE, method="relabundance"),
                      "'name' must be a non-empty single character value")
-        expect_warning(
-            actual <- transformAssay(se, method="relabundance"),
-            "The assay contains only positive values. Applying a pseudocount is not necessary."
-        )
+        actual <- transformAssay(se, method="relabundance")
         expect_named(assays(actual), c("counts", "relabundance"))
 
         expect_equal(assay(actual,"relabundance")[,1],
@@ -166,10 +163,7 @@ test_that("transformAssay", {
         assay(tse, "test2")[1, ] <- 0
         
         # clr robust transformations
-        expect_warning(
-            test <- assay(transformAssay(tse, method = "rclr", assay.type = "test"), "rclr"),
-            "The assay contains only positive values. Applying a pseudocount is not necessary."
-        )
+        test <- assay(transformAssay(tse, method = "rclr", assay.type = "test"), "rclr")
         test2 <- assay(transformAssay(tse, method = "rclr", assay.type = "test2"), "rclr")
 
         # Removes first rows
@@ -196,10 +190,7 @@ test_that("transformAssay", {
 
         # Test that CLR with counts equal to CLR with relabundance
         assay(tse, "pseudo") <- assay(tse, "counts") + 1
-        expect_warning(
-            tse <- transformAssay(tse, assay.type = "pseudo", method = "clr", name = "clr1"),
-            "The assay contains only positive values. Applying a pseudocount is not necessary."
-        )
+        tse <- transformAssay(tse, assay.type = "pseudo", method = "clr", name = "clr1")
         tse <- transformAssay(
             tse, assay.type = "counts", method = "clr", name = "clr2",
             pseudocount =1)
@@ -209,11 +200,7 @@ test_that("transformAssay", {
         tse <- transformAssay(
             tse, assay.type = "counts", method = "relabundance", pseudocount = 1,
             name = "rel_pseudo1")
-        expect_warning(
-            tse <- transformAssay(
-                tse, assay.type = "pseudo", method = "relabundance", name = "rel_pseudo2"),
-            "The assay contains only positive values. Applying a pseudocount is not necessary."
-        )
+        tse <- transformAssay(tse, assay.type = "pseudo", method = "relabundance", name = "rel_pseudo2")
         expect_equal(assay(tse, "rel_pseudo1"), assay(tse, "rel_pseudo2"),
                      check.attributes = FALSE)
         


### PR DESCRIPTION
Hi!

This PR is meant to simplify pseudocount selection for transformations that need a pseudocount, as discussed in [this OMA issue](https://github.com/microbiome/OMA/pull/343).

The option TRUE of `transformAssay` sets pseudocount to smallest positive value of assay, whereas FALSE sets it to 0.