### PR TITLE
Fix pseudocount bug for missing values in assay

### DIFF
--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -551,7 +551,7 @@ setMethod("relAbundanceCounts", signature = c(x = "SummarizedExperiment"),
 .apply_pseudocount <- function(mat, pseudocount){
     if( .is_a_bool(pseudocount) ){
         # If pseudocount TRUE and some negative values, numerical pseudocount needed
-        if ( pseudocount && any(mat<0) ){
+        if ( pseudocount && any(mat < 0, na.rm = TRUE) ){
             stop("The assay contains some negative values. ",
                  "'pseudocount' must be specified manually.", call. = FALSE)
         }
@@ -564,12 +564,12 @@ setMethod("relAbundanceCounts", signature = c(x = "SummarizedExperiment"),
     }
     # Give warning if pseudocount should not be added
     # Case 1: only positive values
-    if( pseudocount != 0 && all(mat>0) ){
+    if( pseudocount != 0 && all(mat > 0) ){
         warning("The assay contains only positive values. ",
                 "Applying a pseudocount may be unnecessary.", call. = FALSE)
     }
     # Case 2: some negative values
-    if( pseudocount != 0 && any(mat<0) ){
+    if( pseudocount != 0 && any(mat < 0, na.rm = TRUE) ){
         warning("The assay contains some negative values. ",
                 "Applying a pseudocount may produce meaningless data.", call. = FALSE)
     }

--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -550,9 +550,9 @@ setMethod("relAbundanceCounts", signature = c(x = "SummarizedExperiment"),
 # This function applies pseudocount to abundance table.
 .apply_pseudocount <- function(mat, pseudocount){
     if( .is_a_bool(pseudocount) ){
-        # If pseudocount TRUE and some negative values, numerical pseudocount needed
-        if ( pseudocount && any(mat < 0, na.rm = TRUE) ){
-            stop("The assay contains some negative values. ",
+        # If pseudocount TRUE but some NAs or negative values, numerical pseudocount needed
+        if ( pseudocount && (any(is.na(mat)) || any(mat < 0, na.rm = TRUE)) ){
+            stop("The assay contains missing or negative values. ",
                  "'pseudocount' must be specified manually.", call. = FALSE)
         }
         # If pseudocount TRUE, set it to non-zero minimum value, else set it to zero
@@ -564,7 +564,7 @@ setMethod("relAbundanceCounts", signature = c(x = "SummarizedExperiment"),
     }
     # Give warning if pseudocount should not be added
     # Case 1: only positive values
-    if( pseudocount != 0 && all(mat > 0) ){
+    if( pseudocount != 0 && all(mat > 0, na.rm = TRUE) ){
         warning("The assay contains only positive values. ",
                 "Applying a pseudocount may be unnecessary.", call. = FALSE)
     }

--- a/tests/testthat/test-5transformCounts.R
+++ b/tests/testthat/test-5transformCounts.R
@@ -156,11 +156,14 @@ test_that("transformAssay", {
         # one value per sample are changed to zero
         tse <- transformAssay(tse, method = "relabundance")
         # Adds pseudocount
-        assay(tse, "test") <- assay(tse, "relabundance")+1
+        assay(tse, "test") <- assay(tse, "relabundance") + 1
         assay(tse, "test2") <- assay(tse, "test")
         assay(tse, "neg_values") <- assay(tse, "counts") - 2
+        assay(tse, "na_values") <- assay(tse, "counts") + 2
         # First row is zeroes
         assay(tse, "test2")[1, ] <- 0
+        # One missing value
+        assay(tse, "na_values")[4, 5] <- NA
         
         # clr robust transformations
         test <- assay(transformAssay(tse, method = "rclr", assay.type = "test"), "rclr")
@@ -183,10 +186,13 @@ test_that("transformAssay", {
         expect_error(transformAssay(tse, assay.type = "relabundance", 
                                      method = "clr"))
         
-        # Expect error when pseudocount TRUE but negative values present
+        # Expect error when pseudocount TRUE but missing or negative values present
         expect_error(transformAssay(tse, method = "relabundance",
                                     assay.type = "neg_values", pseudocount = TRUE),
-                     "The assay contains some negative values. 'pseudocount' must be specified manually.")
+                     "The assay contains missing or negative values. 'pseudocount' must be specified manually.")
+        expect_error(transformAssay(tse, method = "relabundance",
+                                    assay.type = "na_values", pseudocount = TRUE),
+                     "The assay contains missing or negative values. 'pseudocount' must be specified manually.")
 
         # Test that CLR with counts equal to CLR with relabundance
         assay(tse, "pseudo") <- assay(tse, "counts") + 1


### PR DESCRIPTION
Hi!

I fixed this bug from OMA arising when pseudocount is given. It was due to missing values in assay:
```
library(mia)
data("HintikkaXOData", package = "mia")
mae <- HintikkaXOData
transformAssay(mae[[3]], assay.type = "signals",
               MARGIN = "features",
               method = "z", pseudocount = TRUE)

# Error in if (pseudocount && any(mat < 0)) { : 
#   missing value where TRUE/FALSE needed
```