### PR TITLE
Unify parameter description

### DIFF
--- a/R/agglomerate.R
+++ b/R/agglomerate.R
@@ -17,11 +17,7 @@
 #' agglomerated, i.e. summed up. If the assay contains values other than counts 
 #' or absolute values, this can lead to meaningless values being produced. 
 #'
-#' @param x a \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}} or
-#'   a \code{\link[TreeSummarizedExperiment:TreeSummarizedExperiment-class]{TreeSummarizedExperiment}}
-#'
-#' @param rank a single character defining a taxonomic rank. Must be a value of
-#'   \code{taxonomyRanks()} function.
+#' @inheritParams perSampleDominantTaxa
 #'
 #' @param onRankOnly \code{TRUE} or \code{FALSE}: Should information only from
 #'   the specified rank be used or from ranks equal and above? See details.

--- a/R/calculateDMM.R
+++ b/R/calculateDMM.R
@@ -3,31 +3,10 @@
 #' These functions are accessors for functions implemented in the
 #' \code{\link[DirichletMultinomial:DirichletMultinomial-package]{DirichletMultinomial}}
 #' package
-#'
-#' @param x a numeric matrix with samples as rows or a
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   object.
-#'
-#' @param assay.type a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   
-#' @param exprs_values a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead.)
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
+#' @inheritParams calculateUnifrac
 #'
 #' @param k the number of Dirichlet components to fit. See
 #'   \code{\link[DirichletMultinomial:dmn]{dmn}}
-#'
-#' @param BPPARAM A
-#'   \code{\link[BiocParallel:BiocParallelParam-class]{BiocParallelParam}}
-#'   object specifying whether the UniFrac calculation should be parallelized.
-#'
-#' @param transposed Logical scalar, is x transposed with samples in rows?
 #'
 #' @param type the type of measure used for the goodness of fit. One of
 #'   \sQuote{laplace}, \sQuote{AIC} or \sQuote{BIC}.

--- a/R/calculateJSD.R
+++ b/R/calculateJSD.R
@@ -3,27 +3,7 @@
 #' This function calculates the Jensen-Shannon Divergence (JSD) in a
 #' \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
 #' object.
-#'
-#' @param x a numeric matrix or a
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}.
-#'   
-#' @param assay.type a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'
-#' @param exprs_values a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead.)
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
-#'
-#' @param transposed Logical scalar, is x transposed with cells in rows?
-#'
-#' @param BPPARAM A
-#'   \code{\link[BiocParallel:BiocParallelParam-class]{BiocParallelParam}}
-#'   object specifying whether the JSD calculation should be parallelized.
+#' @inheritParams calculateUnifrac
 #'
 #' @param chunkSize an integer scalar, defining the size of data send
 #'   to the individual worker. Only has an effect, if \code{BPPARAM} defines

--- a/R/calculateOverlap.R
+++ b/R/calculateOverlap.R
@@ -3,19 +3,7 @@
 #' This function calculates overlap for all sample-pairs
 #' in a \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
 #' object.
-#'
-#' @param x a
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   object containing a tree.
-#'   
-#' @param assay.type A single character value for selecting the
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assay}}
-#'   to calculate the overlap.
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
+#' @inheritParams estimateDiversity
 #'   
 #' @param detection A single numeric value for selecting detection threshold for 
 #'   absence/presence of features. Feature that has abundance under threshold in

--- a/R/calculateUnifrac.R
+++ b/R/calculateUnifrac.R
@@ -6,10 +6,7 @@
 #'
 #' Please note that if \code{calculateUnifrac} is used as a \code{FUN} for
 #' \code{runMDS}, the argument \code{ntop} has to be set to \code{nrow(x)}.
-#'
-#' @param x a numeric matrix or a
-#'   \code{\link[TreeSummarizedExperiment:TreeSummarizedExperiment-class]{TreeSummarizedExperiment}}
-#'   object containing a tree.
+#' @inheritParams estimateDiversity
 #'
 #'   Please  note that \code{runUnifrac} expects a matrix with samples per row
 #'   and not per column. This is implemented to be compatible with other
@@ -25,22 +22,6 @@
 #'   a \code{character} vector specifying links between rows/columns and tips of \code{tree}.
 #'   The length must equal the number of rows/columns of \code{x}. Furthermore, all the 
 #'   node labs must be present in \code{tree}.
-#'
-#' @param assay.type a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   
-#' @param exprs_values a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead.)
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
-#'
-#' @param tree_name a single \code{character} value for specifying which
-#'   tree will be used in calculation. 
-#'   (By default: \code{tree_name = "phylo"})
 #'   
 #' @param weighted \code{TRUE} or \code{FALSE}: Should use weighted-Unifrac
 #'   calculation? Weighted-Unifrac takes into account the relative abundance of
@@ -53,10 +34,6 @@
 #'   values? Default is \code{TRUE}. Note that (unweighted) \code{Unifrac} is
 #'   always normalized by total branch-length, and so this value is ignored when
 #'   \code{weighted == FALSE}.
-#'
-#' @param BPPARAM A
-#'   \code{\link[BiocParallel:BiocParallelParam-class]{BiocParallelParam}}
-#'   object specifying whether the Unifrac calculation should be parallelized.
 #'
 #' @param transposed Logical scalar, is x transposed with cells in rows, i.e., 
 #'   is Unifrac distance calculated based on rows (FALSE) or columns (TRUE).

--- a/R/cluster.R
+++ b/R/cluster.R
@@ -2,10 +2,7 @@
 #'
 #' This function returns a \code{SummarizedExperiment} with clustering 
 #'   information in its colData or rowData
-#'
-#' @param x A
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   object.
+#' @inheritParams perSampleDominantTaxa
 #'   
 #' @param clust.col A single character value indicating the name of the 
 #'   \code{rowData} (or \code{colData}) where the data will be stored.

--- a/R/decontam.R
+++ b/R/decontam.R
@@ -4,21 +4,9 @@
 #' \code{isNotContaminant} are made available for
 #' \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
 #' objects.
-#'
+#' @inheritParams perSampleDominantTaxa
 #' @param seqtab,x
 #'   a \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'
-#' @param assay.type A single character value for selecting the
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assay}}
-#'   to use.
-#'
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
-#'
-#' @param name A name for the column of the colData in which the contaminant
-#'   information should be stored.
 #'
 #' @param concentration \code{NULL} or a single \code{character} value. Defining
 #'   a column with numeric values from the \code{colData} to use as

--- a/R/dominantTaxa.R
+++ b/R/dominantTaxa.R
@@ -3,19 +3,7 @@
 #' These functions return information about the most dominant taxa in a
 #' \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
 #' object.
-#'
-#' @param x A
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   object.
-#'
-#' @param assay.type A single character value for selecting the
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assay}}
-#'   to use for identifying dominant taxa.
-#'
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
+#' @inheritParams calculateNMDS
 #'   
 #' @param rank A single character defining a taxonomic rank. Must be a value of
 #'   the output of \code{taxonomyRanks()}.

--- a/R/estimateDivergence.R
+++ b/R/estimateDivergence.R
@@ -1,19 +1,7 @@
 #' Estimate divergence
 #'
 #' Estimate divergence against a given reference sample.
-#' 
-#' @param x a \code{\link{SummarizedExperiment}} object.
-#'
-#' @param assay.type the name of the assay used for calculation of the
-#'   sample-wise estimates.
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
-#'
-#' @param name a name for the column of the colData the results should be
-#'   stored in. By default, \code{name} is \code{"divergence"}.
+#' @inheritParams estimateRichness
 #'   
 #' @param reference a numeric vector that has length equal to number of
 #'   features, or a non-empty character value; either 'median' or 'mean'.

--- a/R/estimateDiversity.R
+++ b/R/estimateDiversity.R
@@ -8,28 +8,11 @@
 #' \sQuote{Gini-Simpson}, 
 #' \sQuote{Inverse Simpson}, \sQuote{log-modulo skewness}, and \sQuote{Shannon} 
 #' indices. See details for more information and references.
-#'
-#' @param x a \code{\link{SummarizedExperiment}} object or \code{\link{TreeSummarizedExperiment}}.
-#' The latter is recommended for microbiome data sets and tree-based alpha diversity indices.
+#' @inheritParams estimateRichness
 #' 
 #' @param tree A phylogenetic tree that is used to calculate 'faith' index.
 #'   If \code{x} is a \code{TreeSummarizedExperiment}, \code{rowTree(x)} is 
 #'   used by default.
-#'
-#' @param assay.type the name of the assay used for
-#'   calculation of the sample-wise estimates.
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
-#'
-#' @param index a \code{character} vector, specifying the diversity measures
-#'   to be calculated.
-#'
-#' @param name a name for the column(s) of the colData the results should be
-#'   stored in. By default this will use the original names of the calculated
-#'   indices.
 #'   
 #' @param tree_name a single \code{character} value for specifying which
 #'   rowTree will be used to calculate faith index. 
@@ -39,10 +22,6 @@
 #'   node labels of \code{tree}. If a certain row is not linked with the tree, missing 
 #'   instance should be noted as NA. When NULL, all the rownames should be found from
 #'   the tree. (By default: \code{node_lab = NULL})
-#'
-#' @param BPPARAM A
-#'   \code{\link[BiocParallel:BiocParallelParam-class]{BiocParallelParam}}
-#'   object specifying whether calculation of estimates should be parallelized.
 #'
 #' @param ... optional arguments:
 #' \itemize{

--- a/R/estimateDominance.R
+++ b/R/estimateDominance.R
@@ -5,22 +5,7 @@
 #' \sQuote{Core abundance},
 #' \sQuote{Gini}, \sQuote{McNaughton’s}, \sQuote{Relative}, and
 #' \sQuote{Simpson's} indices.
-#'
-#' @param x a
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   object
-#'
-#' @param assay.type A single character value for selecting the
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assay}}
-#'   to calculate the sample-wise estimates.
-#'
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
-#'   
-#' @param index a \code{character} vector, specifying the indices to be
-#'   calculated.
+#' @inheritParams estimateRichness
 #'
 #' @param ntaxa Optional and only used for the \code{Absolute} and
 #'   \code{Relative} dominance indices: The n-th position of the dominant taxa
@@ -35,14 +20,6 @@
 #'   relative abundance is returned for the single taxa with the indicated rank
 #'   (default: \code{aggregate = TRUE}). Disregarded for the indices
 #'   \dQuote{core_abundance}, \dQuote{gini}, \dQuote{dmn}, and \dQuote{simpson}.
-#'
-#' @param name A name for the column(s) of the colData where the calculated
-#'   Dominance indices should be stored in.
-#'
-#' @param BPPARAM A
-#'   \code{\link[BiocParallel:BiocParallelParam-class]{BiocParallelParam}}
-#'   object specifying whether calculation of estimates should be parallelized.
-#'   (Currently not used)
 #'
 #' @param ... additional arguments currently not used.
 #'

--- a/R/estimateEvenness.R
+++ b/R/estimateEvenness.R
@@ -4,27 +4,7 @@
 #' These include the \sQuote{Camargo}, \sQuote{Pielou}, \sQuote{Simpson},
 #' \sQuote{Evar} and \sQuote{Bulla} evenness measures.
 #' See details for more information and references.
-#'
-#' @param x a \code{\link{SummarizedExperiment}} object
-#'
-#' @param assay.type A single character value for selecting the
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assay}} used for
-#'   calculation of the sample-wise estimates.
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
-#'
-#' @param index a \code{character} vector, specifying the evenness measures to be
-#'   calculated.
-#'
-#' @param name a name for the column(s) of the colData the results should be
-#'   stored in.
-#'
-#' @param BPPARAM A
-#'   \code{\link[BiocParallel:BiocParallelParam-class]{BiocParallelParam}}
-#'   object specifying whether calculation of estimates should be parallelized.
+#' @inheritParams estimateRichness
 #'
 #' @param ... optional arguments:
 #' \itemize{

--- a/R/estimateRichness.R
+++ b/R/estimateRichness.R
@@ -6,22 +6,10 @@
 #' These include the \sQuote{ace}, \sQuote{Chao1}, \sQuote{Hill}, and 
 #' \sQuote{Observed} richness measures.
 #' See details for more information and references.
+#' @inheritParams calculateNMDS
 #'
-#' @param x a \code{\link{SummarizedExperiment}} object.
-#'
-#' @param assay.type the name of the assay used for calculation of the
-#'   sample-wise estimates.
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
-#'   
 #' @param index a \code{character} vector, specifying the richness measures
 #'   to be calculated.
-#'
-#' @param name a name for the column(s) of the colData the results should be
-#'   stored in.
 #'
 #' @param detection a numeric value for selecting detection threshold
 #' for the abundances. The default detection threshold is 0.

--- a/R/getCrossAssociation.R
+++ b/R/getCrossAssociation.R
@@ -1,9 +1,5 @@
 #' Calculate correlations between features of two experiments.
-#' 
-#' @param x A
-#'   \code{\link[MultiAssayExperiment:MultiAssayExperiment-class]{MultiAssayExperiment}} or
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   object.
+#' @inheritParams transformAssay
 #'   
 #' @param experiment1 A single character or numeric value for selecting the experiment 1
 #'    from \code{experiments(x)} of \code{MultiassayExperiment} object. 
@@ -51,14 +47,6 @@
 #' @param colData_variable2 A character value specifying column(s) from colData
 #'   of experiment 2. If colData_variable2 is used, assay.type2 is disabled.
 #'   (By default: \code{colData_variable2 = NULL})
-#' 
-#' @param MARGIN A single numeric value for selecting if association are calculated
-#'   row-wise / for features (1) or column-wise / for samples (2). Must be \code{1} or
-#'   \code{2}. (By default: \code{MARGIN = 1}) 
-#'   
-#' @param method A single character value for selecting association method 
-#'    ('kendall', pearson', or 'spearman' for continuous/numeric; 'categorical' for discrete)
-#'     (By default: \code{method = "kendall"})
 #' 
 #' @param mode A single character value for selecting output format 
 #'    Available formats are  'table' and 'matrix'.  (By default: \code{mode = "table"})

--- a/R/getPrevalence.R
+++ b/R/getPrevalence.R
@@ -2,10 +2,7 @@
 #'
 #' These functions calculate the population prevalence for taxonomic ranks in a
 #' \code{\link{SummarizedExperiment-class}} object.
-#'
-#' @param x a
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   object
+#' @inheritParams perSampleDominantTaxa
 #'
 #' @param detection Detection threshold for absence/presence. Either an
 #'   absolute value compared directly to the values of \code{x} or a relative
@@ -19,18 +16,7 @@
 #'
 #' @param as_relative logical scalar: Should the detection threshold be applied
 #'   on compositional (relative) abundances? (default: \code{FALSE})
-#'
-#' @param assay.type A single character value for selecting the
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assay}}
-#'   to use for prevalence calculation.
 #'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
-#'   
-#' @param rank a single character defining a taxonomic rank. Must be a value of
-#'   \code{taxonomyRanks()} function.
 #'  
 #' @param na.rm logical scalar: Should NA values be omitted when calculating
 #' prevalence? (default: \code{na.rm = TRUE})

--- a/R/importHumann.R
+++ b/R/importHumann.R
@@ -1,12 +1,5 @@
 #' Import HUMAnN results to \code{TreeSummarizedExperiment}
-#
-#' @param file a single \code{character} value defining the file
-#' path of the HUMAnN file. The file must be in merged HUMAnN format.
-#'
-#' @param colData a DataFrame-like object that includes sample names in
-#' rownames, or a single \code{character} value defining the file
-#' path of the sample metadata file. The file must be in \code{tsv} format
-#' (default: \code{colData = NULL}).
+#' @inheritParams loadFromMetaphlan
 #' 
 #' @param ... additional arguments:
 #' \itemize{

--- a/R/makephyloseqFromTreeSummarizedExperiment.R
+++ b/R/makephyloseqFromTreeSummarizedExperiment.R
@@ -3,22 +3,7 @@
 #' This function creates a phyloseq object from a TreeSummarizedExperiment
 #' object. By using \code{assay.type}, it is possible to specify which table
 #' from \code{assay} is added to the phyloseq object.
-#'
-#' @param x a \code{TreeSummarizedExperiment} object
-#'
-#' @param assay.type A single character value for selecting the
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assay}} to be
-#'   included in the phyloseq object that is created. 
-#'   (By default: \code{assay.type = "counts"})
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
-#'   
-#' @param tree_name a single \code{character} value for specifying which
-#'   tree will be included in the phyloseq object that is created, 
-#'   (By default: \code{tree_name = "phylo"})
+#' @inheritParams calculateDPCoA
 #'
 #' @param ... additional arguments
 #'

--- a/R/meltAssay.R
+++ b/R/meltAssay.R
@@ -10,17 +10,7 @@
 #' \code{rowData} contains a column \dQuote{FeatureID}, they will be renamed to
 #' \dQuote{SampleID_col} and \dQuote{FeatureID_row}, if row names or column
 #' names are set.
-#'
-#' @param x A numeric matrix or a
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   
-#' @param assay.type a \code{character} value to select an
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assayNames}}
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
+#' @inheritParams calculateNMDS
 #'
 #' @param add_col_data \code{NULL}, \code{TRUE} or a \code{character} vector to
 #'   select information from the \code{colData} to add to the molten assay data.

--- a/R/mergeSEs.R
+++ b/R/mergeSEs.R
@@ -1,16 +1,8 @@
 #' Merge SE objects into single SE object.
-#' 
-#' @param x a \code{\link{SummarizedExperiment}} object or a list of 
-#' \code{\link{SummarizedExperiment}} objects.
+#' @inheritParams subsampleCounts
 #' 
 #' @param y a \code{\link{SummarizedExperiment}} object when \code{x} is a
 #' \code{\link{SummarizedExperiment}} object. Disabled when \code{x} is a list.
-#' 
-#' @param assay.type A character value for selecting the
-#' \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assay}}
-#' to be merged. (By default: \code{assay.type = "counts"})
-#'
-#' @param assay_name (Deprecated) alias for \code{assay.type}. 
 #' 
 #' @param join A single character value for selecting the joining method.
 #' Must be 'full', 'inner', 'left', or 'right'. 'left' and 'right' are disabled
@@ -30,9 +22,6 @@
 #' option, it is possible to specify whether these strains are combined if their
 #' taxonomy information along with OTU number matches.
 #' (By default: \code{collapse_features = TRUE})
-#' 
-#' @param verbose A single boolean value to choose whether to show messages. 
-#' (By default: \code{verbose = TRUE})
 #'
 #' @param ... optional arguments (not used).
 #'

--- a/R/rarefyAssay.R
+++ b/R/rarefyAssay.R
@@ -12,19 +12,7 @@
 #' input and any result have to be verified with the original dataset.
 #' To maintain the reproducibility, please define the seed using set.seed() 
 #' before implement this function.
-#'
-#' @param x A
-#'   \code{SummarizedExperiment} object.
-#'
-#' @param assay.type A single character value for selecting the
-#'   \code{SummarizedExperiment} \code{assay} used for random subsampling. 
-#'   Only counts are useful and other transformed data as input will give 
-#'   meaningless output.
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
+#' @inheritParams calculateNMDS
 #'   
 #' @param min_size A single integer value equal to the number of counts being 
 #'   simulated this can equal to lowest number of total counts 

--- a/R/relabundance.R
+++ b/R/relabundance.R
@@ -4,8 +4,7 @@
 #' Please use \code{assay(x, "relabundance")} instead, which provides a more
 #' flexible and robust way to access and modify relative abundance data stored
 #' in the assay slot of a \code{\link[TreeSummarizedExperiment:TreeSummarizedExperiment-class]{TreeSummarizedExperiment}} object.
-#'
-#' @param x a \code{\link[TreeSummarizedExperiment:TreeSummarizedExperiment-class]{TreeSummarizedExperiment}} object
+#' @inheritParams transformAssay
 #' @param value a matrix to store as the \sQuote{relabundance} assay
 #' @param ... optional arguments not used currently.
 #'

--- a/R/runCCA.R
+++ b/R/runCCA.R
@@ -2,10 +2,7 @@
 #'
 #' These functions perform Canonical Correspondence Analysis on data stored
 #' in a \code{SummarizedExperiment}.
-#'
-#' @param x For \code{calculate*} a 
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}} 
-#'   or a numeric matrix with columns as samples 
+#' @inheritParams calculateNMDS
 #'
 #'   For \code{run*} a
 #'   \code{\link[SingleCellExperiment:SingleCellExperiment]{SingleCellExperiment}}
@@ -33,24 +30,6 @@
 #'   multivariate homogeneity of group dispersions be performed.
 #'   (By default: \code{test.signif = TRUE})
 #'
-#' @param assay.type a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'
-#' @param exprs_values a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead.)
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
-#'   
-#' @param altexp String or integer scalar specifying an alternative experiment
-#'   containing the input data.
-#'
-#' @param name String specifying the name to be used to store the result in the
-#'   reducedDims of the output.
-#' 
 #' @param scores A string specifying scores to be returned. Must be
 #' 'wa' (site scores found as weighted averages (cca) or weighted sums (rda) of
 #' v with weights Xbar, but the multiplying effect of eigenvalues removed) or

--- a/R/runDPCoA.R
+++ b/R/runDPCoA.R
@@ -3,10 +3,7 @@
 #' Double Principal Correspondance analysis is made available via the
 #' \code{ade4} package in typical fashion. Results are stored in the
 #' \code{reducedDims} and are available for all the expected functions.
-#'
-#' @param x For \code{calculateDPCoA}, a numeric matrix of expression values
-#'   where rows are features and columns are cells.
-#'   Alternatively, a \code{TreeSummarizedExperiment} containing such a matrix.
+#' @inheritParams calculateNMDS
 #'
 #'   For \code{runDPCoA} a \linkS4class{TreeSummarizedExperiment} containing the
 #'   expression values as well as a \code{rowTree} to calculate \code{y} using
@@ -14,43 +11,10 @@
 #'
 #' @param y a \code{dist} or a symmetric \code{matrix} compatible with
 #'   \code{ade4:dpcoa}
-#'
-#' @param ncomponents Numeric scalar indicating the number of DPCoA dimensions
-#'   to obtain.
-#'
-#' @param ntop Numeric scalar specifying the number of features with the highest
-#'   variances to use for dimensionality reduction. Alternatively \code{NULL},
-#'   if all features should be used. (default: \code{ntop = NULL})
-#'
-#' @param subset_row Vector specifying the subset of features to use for
-#'   dimensionality reduction. This can be a character vector of row names, an
-#'   integer vector of row indices or a logical vector.
-#'
-#' @param scale Logical scalar, should the expression values be standardized?
-#'
-#' @param transposed Logical scalar, is x transposed with cells in rows?
-#'
-#' @param assay.type a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   
-#' @param exprs_values a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead.)
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
 #'   
 #' @param tree_name a single \code{character} value for specifying which
 #'   rowTree will be used in calculation. 
 #'   (By default: \code{tree_name = "phylo"})
-#'
-#' @param altexp String or integer scalar specifying an alternative experiment
-#'   containing the input data.
-#'
-#' @param name String specifying the name to be used to store the result in the
-#'   reducedDims of the output.
 #'
 #' @param ... Currently not used.
 #'

--- a/R/runNMDS.R
+++ b/R/runNMDS.R
@@ -13,7 +13,8 @@
 #'   to obtain.
 #'
 #' @param ntop Numeric scalar specifying the number of features with the highest
-#'   variances to use for dimensionality reduction.
+#'   variances to use for dimensionality reduction. Alternatively \code{NULL},
+#'   if all features should be used. (default: \code{ntop = NULL})
 #'
 #' @param subset_row Vector specifying the subset of features to use for
 #'   dimensionality reduction. This can be a character vector of row names, an

--- a/R/splitByRanks.R
+++ b/R/splitByRanks.R
@@ -7,18 +7,10 @@
 #' 
 #' \code{unsplitByRanks} takes these alternative experiments and flattens them 
 #' again into a single \code{SummarizedExperiment}.
-#'
-#' @param x a
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   object
+#' @inheritParams mergeFeaturesByRank
 #'
 #' @param ranks a character vector defining taxonomic ranks. Must all be values
 #'   of \code{taxonomyRanks()} function.
-#'
-#' @param na.rm \code{TRUE} or \code{FALSE}: Should taxa with an empty rank be
-#'   removed? Use it with caution, since results with NA on the selected rank
-#'   will be dropped. This setting can be tweaked by defining
-#'   \code{empty.fields} to your needs. (default: \code{na.rm = TRUE})
 #'
 #' @param keep_reducedDims \code{TRUE} or \code{FALSE}: Should the
 #'   \code{reducedDims(x)} be transferred to the result? Please note, that this

--- a/R/splitOn.R
+++ b/R/splitOn.R
@@ -1,10 +1,5 @@
 #' Split \code{TreeSummarizedExperiment} column-wise or row-wise based on grouping variable
-#'
-#' @param x A
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   object or a list of 
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   objects.
+#' @inheritParams calculateNMDS
 #'
 #' @param f A single character value for selecting the grouping variable
 #'   from \code{rowData} or \code{colData} or a \code{factor} or \code{vector} 

--- a/R/subset.R
+++ b/R/subset.R
@@ -9,10 +9,7 @@
 #' both dimension at the same time, is more flexible and is used throughout R to
 #' subset data with two or more dimension. Therefore, these functions will be
 #' removed in Bioconductor release 3.15 (April, 2022).
-#'
-#' @param x a
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   object
+#' @inheritParams transformAssay
 #'
 #' @param ... See \code{\link[BiocGenerics:subset]{subset}}. \code{drop} is
 #'   not supported.

--- a/R/summaries.R
+++ b/R/summaries.R
@@ -2,23 +2,10 @@
 #'
 #' To query a \code{SummarizedExperiment} for interesting features, several
 #' functions are available.
-#'
-#' @param x A
-#'  \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}} object.
+#' @inheritParams transformAssay
 #'
 #' @param top Numeric value, how many top taxa to return. Default return top
 #'   five taxa.
-#'
-#' @param method Specify the method to determine top taxa. Either sum, mean,
-#'   median or prevalence. Default is 'mean'.
-#'
-#' @param assay.type A \code{character} value to select an
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assayNames}} 
-#'   
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
 #'   
 #' @param na.rm For \code{getTop} logical argument for calculation method 
 #'              specified to argument \code{method}. Default is TRUE. 

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -28,13 +28,7 @@
 #'   not provided, then all matching taxonomy rows in \code{rowData} will be
 #'   returned. This function allows handy conversions between different
 #    taxonomic levels.
-#'
-#' @param x a
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'   object
-#'
-#' @param rank a single character defining a taxonomic rank. Must be a value of
-#'   \code{taxonomyRanks()} function
+#' @inheritParams perSampleDominantTaxa
 #'
 #' @param empty.fields a \code{character} value defining, which values should be
 #'   regarded as empty. (Default: \code{c(NA, "", " ", "\t")}). They will be

--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -2,29 +2,15 @@
 #'
 #' Variety of transformations for abundance data, stored in \code{assay}.
 #' See details for options.
-#'
-#' @param x A
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
-#'    object.
-#'
-#' @param assay.type A single character value for selecting the
-#'   \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assay}} to be
-#'   transformed.
-#'
-#' @param assay_name a single \code{character} value for specifying which
-#'   assay to use for calculation.
-#'   (Please use \code{assay.type} instead. At some point \code{assay_name}
-#'   will be disabled.)
+#' @inheritParams calculateNMDS
 #'   
-#' @param method A single character value for selecting the transformation
-#'   method.
+#' @param method A single character value for selecting association method 
+#'    ('kendall', pearson', or 'spearman' for continuous/numeric; 'categorical' for discrete)
+#'     (By default: \code{method = "kendall"})
 #' 
-#' @param MARGIN A single character value for specifying whether the
-#'   transformation is applied sample (column) or feature (row) wise.
-#'   (By default: \code{MARGIN = "samples"})
-#'
-#' @param name A single character value specifying the name of transformed
-#'   abundance table.
+#' @param MARGIN A single numeric value for selecting if association are calculated
+#'   row-wise / for features (1) or column-wise / for samples (2). Must be \code{1} or
+#'   \code{2}. (By default: \code{MARGIN = 1}) 
 #' 
 #' @param pseudocount TRUE, FALSE, or a numeric value. When TRUE,
 #'   automatically adds the minimum positive value of \code{assay.type}.


### PR DESCRIPTION
1- We have used @inheritParams to harmonize parameter desc. 
Mentioning issue #458  and #372

TODO: harmonize parameter naming with dot naming(e.g on.rank.only)
