### PR TITLE
Manpage clean-up

### DIFF
--- a/R/agglomerate.R
+++ b/R/agglomerate.R
@@ -1,7 +1,7 @@
 #' Agglomerate data using taxonomic information
 #'
-#' \code{agglomerateByRank} can be used to sum up data based on the association
-#' to certain taxonomic ranks given as \code{rowData}. Only available
+#' \code{agglomerateByRank} can be used to sum up data based on associations
+#' with certain taxonomic ranks, as defined in \code{rowData}. Only available
 #' \code{\link{taxonomyRanks}} can be used.
 #'
 #' @param x a
@@ -49,16 +49,16 @@
 #'   \code{strip_altexp = TRUE})
 #'
 #' @details
-#' Based on the available taxonomic data and its structure setting
+#' Depending on the available taxonomic data and its structure, setting
 #' \code{onRankOnly = TRUE} has certain implications on the interpretability of
 #' your results. If no loops exist (loops meaning two higher ranks containing
-#' the same lower rank), the results should be comparable. you can check for
+#' the same lower rank), the results should be comparable. You can check for
 #' loops using \code{\link[TreeSummarizedExperiment:detectLoop]{detectLoop}}.
 #' 
-#' Agglomeration sum up values of assays at specified taxonomic level. Certain assays,
-#' e.g. those that include binary or negative values, can lead to meaningless values, 
-#' when values are summed. In those cases, consider doing agglomeration first and then 
-#' transformation.
+#' Agglomeration sums up the values of assays at the specified taxonomic level. With
+#' certain assays, e.g. those that include binary or negative values, this summing
+#' can produce meaningless values. In those cases, consider performing agglomeration
+#' first, and then applying the transformation afterwards.
 #'
 #' @return A taxonomically-agglomerated, optionally-pruned object of the same
 #'   class as \code{x}.
@@ -80,7 +80,7 @@
 #' nrow(GlobalPatterns)
 #' nrow(x1)
 #' 
-#' # with agglomeration of the tree
+#' # agglomerate the tree as well
 #' x2 <- agglomerateByRank(GlobalPatterns, rank="Family",
 #'                        agglomerateTree = TRUE)
 #' nrow(x2) # same number of rows, but
@@ -111,21 +111,21 @@
 #' x4 <- agglomerateByRank(GlobalPatterns, rank="Phylum", remove_empty_ranks = TRUE)
 #' head(rowData(x4))
 #' 
-#' # If assay contains NAs, you might want to consider replacing them since summing-up
-#' # NAs lead to NA
+#' # If the assay contains NAs, you might want to consider replacing them,
+#' # since summing-up NAs lead to NA
 #' x5 <- GlobalPatterns
 #' # Replace first value with NA
 #' assay(x5)[1,1] <- NA
 #' x6 <- agglomerateByRank(x5, "Kingdom")
 #' head( assay(x6) )
-#' # Replace NAs with 0. It is justified when we are summing-up counts
+#' # Replace NAs with 0. This is justified when we are summing-up counts.
 #' assay(x5)[ is.na(assay(x5)) ] <- 0
 #' x6 <- agglomerateByRank(x5, "Kingdom")
 #' head( assay(x6) )
 #' 
 #' ## Look at enterotype dataset...
 #' data(enterotype)
-#' ## print the available taxonomic ranks. Shows only 1 rank available
+#' ## Print the available taxonomic ranks. Shows only 1 available rank,
 #' ## not useful for agglomerateByRank
 #' taxonomyRanks(enterotype)
 NULL

--- a/R/calculateDMM.R
+++ b/R/calculateDMM.R
@@ -95,7 +95,7 @@
 #' bestModel
 #' 
 #' # Get the sample-cluster assignment probability matrix
-#' metadata(tse)$DMM$prob
+#' head(metadata(tse)$DMM$prob)
 #' 
 #' # Get the weight of each component for the best model
 #' bestModel@mixture$Weight

--- a/R/getExperimentCrossAssociation.R
+++ b/R/getExperimentCrossAssociation.R
@@ -140,6 +140,9 @@
 #' # Subset so that less observations / quicker to run, just for example
 #' mae[[1]] <- mae[[1]][1:20, 1:10]
 #' mae[[2]] <- mae[[2]][1:20, 1:10]
+#' # Several rows in the counts assay have a standard deviation of zero
+#' # Remove them, since they do not add useful information about cross-association
+#' mae[[1]] <- mae[[1]][rowSds(assay(mae[[1]])) > 0, ]
 #' # Transform data
 #' mae[[1]] <- transformAssay(mae[[1]], method = "rclr")
 #' 
@@ -152,7 +155,7 @@
 #' altExp(mae[[1]], "Phylum") <- agglomerateByRank(mae[[1]], rank = "Phylum")
 #' # Transform data
 #' altExp(mae[[1]], "Phylum") <- transformAssay(altExp(mae[[1]], "Phylum"), method = "relabundance")
-#' # When mode = matrix, matrix is returned
+#' # When mode = "matrix", the return value is a matrix
 #' result <- getExperimentCrossAssociation(mae, experiment2 = 2, 
 #'                                         assay.type1 = "relabundance", assay.type2 = "nmr",
 #'                                         altexp1 = "Phylum", 
@@ -160,18 +163,18 @@
 #' # Show first 5 entries
 #' head(result, 5)
 #' 
-#' # testExperimentCorrelation returns also significances
+#' # testExperimentCorrelation additionally returns significances
 #' # filter_self_correlations = TRUE filters self correlations
-#' # With p_adj_threshold it is possible to filter those features that do no have
-#' # any correlations that have p-value under threshold
+#' # p_adj_threshold can be used to filter those features that do not
+#' # have any correlations whose p-value is lower than the threshold
 #' result <- testExperimentCrossAssociation(mae[[1]], experiment2 = mae[[1]], method = "pearson",
 #'                                          filter_self_correlations = TRUE,
 #'                                          p_adj_threshold = 0.05)
 #' # Show first 5 entries
 #' head(result, 5)
 #' 
-#' # Also getExperimentCrossAssociation returns significances when 
-#' # test_signicance = TRUE
+#' # getExperimentCrossAssociation also returns significances when 
+#' # test_significance = TRUE
 #' # Warnings can be suppressed by using show_warnings = FALSE
 #' result <- getExperimentCrossAssociation(mae[[1]], experiment2 = mae[[2]], method = "pearson",
 #'                                         assay.type2 = "nmr",
@@ -195,9 +198,10 @@
 #'                                         assay.type1 = "counts", assay.type2 = "counts",
 #'                                         symmetric = TRUE)
 #' 
-#' # For big data sets, calculation might take long. To make calculations quicker, you can take
-#' # a random sample from data. In a complex biological problems, random sample
-#' # can describe the data enough. Here our random sample is 30 % of whole data.
+#' # For big data sets, the calculations might take a long time.
+#' # To speed them up, you can take a random sample from the data. 
+#' # When dealing with complex biological problems, random samples can be 
+#' # enough to describe the data. Here, our random sample is 30 % of whole data.
 #' sample_size <- 0.3
 #' tse <- mae[[1]]
 #' tse_sub <- tse[ sample( seq_len( nrow(tse) ), sample_size * nrow(tse) ), ]

--- a/R/merge.R
+++ b/R/merge.R
@@ -6,8 +6,8 @@
 #' retained as defined by \code{archetype}.
 #' 
 #' \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assay}} are 
-#' agglomerated, i.e.. summed up. Other than counts / absolute values might lead
-#' to meaningless values. 
+#' agglomerated, i.e. summed up. If the assay contains values other than counts 
+#' or absolute values, this can lead to meaningless values being produced. 
 #'
 #' @param x a \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}} or
 #'   a \code{\link[TreeSummarizedExperiment:TreeSummarizedExperiment-class]{TreeSummarizedExperiment}}
@@ -23,18 +23,19 @@
 #'   as \code{levels(f)}. (Default: \code{archetype = 1L}, which means the first
 #'   element encountered per factor level will be kept)
 #'   
-#' @param mergeTree \code{TRUE} or \code{FALSE}: should to
+#' @param mergeTree \code{TRUE} or \code{FALSE}: Should
 #'   \code{rowTree()} also be merged? (Default: \code{mergeTree = FALSE})
 #'
-#' @param mergeRefSeq \code{TRUE} or \code{FALSE}: should a consensus sequence
-#'   calculate? If set to \code{FALSE}, the result from \code{archetype} is
+#' @param mergeRefSeq \code{TRUE} or \code{FALSE}: Should a consensus sequence
+#'   be calculated? If set to \code{FALSE}, the result from \code{archetype} is
 #'   returned; If set to \code{TRUE} the result from
 #'   \code{\link[DECIPHER:ConsensusSequence]{DECIPHER::ConsensusSequence}} is
 #'   returned. (Default: \code{mergeRefSeq = FALSE})
 #'
-#' @param ... optional arguments:
+#' @param ... Optional arguments:
 #' \itemize{
-#'   \item{passed onto \code{\link[scuttle:sumCountsAcrossFeatures]{sumCountsAcrossFeatures}}, except \code{subset_row}, \code{subset_col}}
+#'   \item{Passed on to \code{\link[scuttle:sumCountsAcrossFeatures]{sumCountsAcrossFeatures}},
+#'   with the exception of \code{subset_row}, \code{subset_col}}
 #' }
 #'
 #' @details
@@ -49,7 +50,7 @@
 #' @name merge-methods
 #' @aliases mergeRows mergeCols
 #'
-#' @return an object with the same class \code{x} with the specified entries
+#' @return An object of the same class as \code{x} with the specified entries
 #'   merged into one entry in all relevant components.
 #'
 #' @seealso

--- a/R/splitOn.R
+++ b/R/splitOn.R
@@ -72,8 +72,8 @@
 #' se_list
 #' 
 #' # Create arbitrary groups
-#' rowData(tse)$group <- sample(1:10, nrow(tse), replace = TRUE)
-#' colData(tse)$group <- sample(1:10, ncol(tse), replace = TRUE)
+#' rowData(tse)$group <- sample(1:3, nrow(tse), replace = TRUE)
+#' colData(tse)$group <- sample(1:3, ncol(tse), replace = TRUE)
 #' 
 #' # Split based on rows
 #' # Each element is named based on their group name. If you don't want to name

--- a/man/agglomerate-methods.Rd
+++ b/man/agglomerate-methods.Rd
@@ -92,21 +92,21 @@ A taxonomically-agglomerated, optionally-pruned object of the same
 class as \code{x}.
 }
 \description{
-\code{agglomerateByRank} can be used to sum up data based on the association
-to certain taxonomic ranks given as \code{rowData}. Only available
+\code{agglomerateByRank} can be used to sum up data based on associations
+with certain taxonomic ranks, as defined in \code{rowData}. Only available
 \code{\link{taxonomyRanks}} can be used.
 }
 \details{
-Based on the available taxonomic data and its structure setting
+Depending on the available taxonomic data and its structure, setting
 \code{onRankOnly = TRUE} has certain implications on the interpretability of
 your results. If no loops exist (loops meaning two higher ranks containing
-the same lower rank), the results should be comparable. you can check for
+the same lower rank), the results should be comparable. You can check for
 loops using \code{\link[TreeSummarizedExperiment:detectLoop]{detectLoop}}.
 
-Agglomeration sum up values of assays at specified taxonomic level. Certain assays,
-e.g. those that include binary or negative values, can lead to meaningless values,
-when values are summed. In those cases, consider doing agglomeration first and then
-transformation.
+Agglomeration sums up the values of assays at the specified taxonomic level. With
+certain assays, e.g. those that include binary or negative values, this summing
+can produce meaningless values. In those cases, consider performing agglomeration
+first, and then applying the transformation afterwards.
 }
 \examples{
 data(GlobalPatterns)
@@ -120,7 +120,7 @@ x1 <- agglomerateByRank(GlobalPatterns, rank="Family")
 nrow(GlobalPatterns)
 nrow(x1)
 
-# with agglomeration of the tree
+# agglomerate the tree as well
 x2 <- agglomerateByRank(GlobalPatterns, rank="Family",
                        agglomerateTree = TRUE)
 nrow(x2) # same number of rows, but
@@ -151,21 +151,21 @@ print(rownames(x3[1:3,]))
 x4 <- agglomerateByRank(GlobalPatterns, rank="Phylum", remove_empty_ranks = TRUE)
 head(rowData(x4))
 
-# If assay contains NAs, you might want to consider replacing them since summing-up
-# NAs lead to NA
+# If the assay contains NAs, you might want to consider replacing them,
+# since summing-up NAs lead to NA
 x5 <- GlobalPatterns
 # Replace first value with NA
 assay(x5)[1,1] <- NA
 x6 <- agglomerateByRank(x5, "Kingdom")
 head( assay(x6) )
-# Replace NAs with 0. It is justified when we are summing-up counts
+# Replace NAs with 0. This is justified when we are summing-up counts.
 assay(x5)[ is.na(assay(x5)) ] <- 0
 x6 <- agglomerateByRank(x5, "Kingdom")
 head( assay(x6) )
 
 ## Look at enterotype dataset...
 data(enterotype)
-## print the available taxonomic ranks. Shows only 1 rank available
+## Print the available taxonomic ranks. Shows only 1 available rank,
 ## not useful for agglomerateByRank
 taxonomyRanks(enterotype)
 }

--- a/man/calculateDMN.Rd
+++ b/man/calculateDMN.Rd
@@ -179,7 +179,7 @@ bestModel <- metadata(tse)$DMM$dmm[[bestFit]]
 bestModel
 
 # Get the sample-cluster assignment probability matrix
-metadata(tse)$DMM$prob
+head(metadata(tse)$DMM$prob)
 
 # Get the weight of each component for the best model
 bestModel@mixture$Weight

--- a/man/getExperimentCrossAssociation.Rd
+++ b/man/getExperimentCrossAssociation.Rd
@@ -194,6 +194,9 @@ mae <- HintikkaXOData
 # Subset so that less observations / quicker to run, just for example
 mae[[1]] <- mae[[1]][1:20, 1:10]
 mae[[2]] <- mae[[2]][1:20, 1:10]
+# Several rows in the counts assay have a standard deviation of zero
+# Remove them, since they do not add useful information about cross-association
+mae[[1]] <- mae[[1]][rowSds(assay(mae[[1]])) > 0, ]
 # Transform data
 mae[[1]] <- transformAssay(mae[[1]], method = "rclr")
 
@@ -206,7 +209,7 @@ head(result, 5)
 altExp(mae[[1]], "Phylum") <- agglomerateByRank(mae[[1]], rank = "Phylum")
 # Transform data
 altExp(mae[[1]], "Phylum") <- transformAssay(altExp(mae[[1]], "Phylum"), method = "relabundance")
-# When mode = matrix, matrix is returned
+# When mode = "matrix", the return value is a matrix
 result <- getExperimentCrossAssociation(mae, experiment2 = 2, 
                                         assay.type1 = "relabundance", assay.type2 = "nmr",
                                         altexp1 = "Phylum", 
@@ -214,18 +217,18 @@ result <- getExperimentCrossAssociation(mae, experiment2 = 2,
 # Show first 5 entries
 head(result, 5)
 
-# testExperimentCorrelation returns also significances
+# testExperimentCorrelation additionally returns significances
 # filter_self_correlations = TRUE filters self correlations
-# With p_adj_threshold it is possible to filter those features that do no have
-# any correlations that have p-value under threshold
+# p_adj_threshold can be used to filter those features that do not
+# have any correlations whose p-value is lower than the threshold
 result <- testExperimentCrossAssociation(mae[[1]], experiment2 = mae[[1]], method = "pearson",
                                          filter_self_correlations = TRUE,
                                          p_adj_threshold = 0.05)
 # Show first 5 entries
 head(result, 5)
 
-# Also getExperimentCrossAssociation returns significances when 
-# test_signicance = TRUE
+# getExperimentCrossAssociation also returns significances when 
+# test_significance = TRUE
 # Warnings can be suppressed by using show_warnings = FALSE
 result <- getExperimentCrossAssociation(mae[[1]], experiment2 = mae[[2]], method = "pearson",
                                         assay.type2 = "nmr",
@@ -249,9 +252,10 @@ result <- getExperimentCrossAssociation(mae, experiment1 = "microbiota", experim
                                         assay.type1 = "counts", assay.type2 = "counts",
                                         symmetric = TRUE)
 
-# For big data sets, calculation might take long. To make calculations quicker, you can take
-# a random sample from data. In a complex biological problems, random sample
-# can describe the data enough. Here our random sample is 30 \% of whole data.
+# For big data sets, the calculations might take a long time.
+# To speed them up, you can take a random sample from the data. 
+# When dealing with complex biological problems, random samples can be 
+# enough to describe the data. Here, our random sample is 30 \% of whole data.
 sample_size <- 0.3
 tse <- mae[[1]]
 tse_sub <- tse[ sample( seq_len( nrow(tse) ), sample_size * nrow(tse) ), ]

--- a/man/merge-methods.Rd
+++ b/man/merge-methods.Rd
@@ -63,22 +63,23 @@ This can be single integer value or an integer vector of the same length
 as \code{levels(f)}. (Default: \code{archetype = 1L}, which means the first
 element encountered per factor level will be kept)}
 
-\item{...}{optional arguments:
+\item{...}{Optional arguments:
 \itemize{
-\item{passed onto \code{\link[scuttle:sumCountsAcrossFeatures]{sumCountsAcrossFeatures}}, except \code{subset_row}, \code{subset_col}}
+\item{Passed on to \code{\link[scuttle:sumCountsAcrossFeatures]{sumCountsAcrossFeatures}},
+with the exception of \code{subset_row}, \code{subset_col}}
 }}
 
-\item{mergeTree}{\code{TRUE} or \code{FALSE}: should to
+\item{mergeTree}{\code{TRUE} or \code{FALSE}: Should
 \code{rowTree()} also be merged? (Default: \code{mergeTree = FALSE})}
 
-\item{mergeRefSeq}{\code{TRUE} or \code{FALSE}: should a consensus sequence
-calculate? If set to \code{FALSE}, the result from \code{archetype} is
+\item{mergeRefSeq}{\code{TRUE} or \code{FALSE}: Should a consensus sequence
+be calculated? If set to \code{FALSE}, the result from \code{archetype} is
 returned; If set to \code{TRUE} the result from
 \code{\link[DECIPHER:ConsensusSequence]{DECIPHER::ConsensusSequence}} is
 returned. (Default: \code{mergeRefSeq = FALSE})}
 }
 \value{
-an object with the same class \code{x} with the specified entries
+An object of the same class as \code{x} with the specified entries
 merged into one entry in all relevant components.
 }
 \description{
@@ -89,8 +90,8 @@ retained as defined by \code{archetype}.
 }
 \details{
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{assay}} are
-agglomerated, i.e.. summed up. Other than counts / absolute values might lead
-to meaningless values.
+agglomerated, i.e. summed up. If the assay contains values other than counts
+or absolute values, this can lead to meaningless values being produced.
 
 These functions are similar to
 \code{\link[scuttle:sumCountsAcrossFeatures]{sumCountsAcrossFeatures}}.

--- a/man/splitOn.Rd
+++ b/man/splitOn.Rd
@@ -89,8 +89,8 @@ se_list <- splitOn(tse, f = "SampleType")
 se_list
 
 # Create arbitrary groups
-rowData(tse)$group <- sample(1:10, nrow(tse), replace = TRUE)
-colData(tse)$group <- sample(1:10, ncol(tse), replace = TRUE)
+rowData(tse)$group <- sample(1:3, nrow(tse), replace = TRUE)
+colData(tse)$group <- sample(1:3, ncol(tse), replace = TRUE)
 
 # Split based on rows
 # Each element is named based on their group name. If you don't want to name


### PR DESCRIPTION
I've gone through the reference pages and cleaned up some unwieldy example outputs as suggested in #450. I mainly spotted three big issues.

- In 41688b42620ef319909e51bb08dff6ddf13b3f49, I've used `head()` to avoid printing the whole probability matrix in https://microbiome.github.io/mia/reference/calculateDMN.html.
- In 13a55fb98987868c67f8522195f4e81a4f6f54f9, I've removed rows with zero standard deviation from the assay to eliminate the large warning chunks in https://microbiome.github.io/mia/reference/getExperimentCrossAssociation.html. The second assay used in the example also has some NA values, but I haven't changed those since they don't produce too many warnings, and one of the examples demonstrates the use of `show_warnings=FALSE`.
- In ecf30870a57b1715ecc8f9323e8d362efe22f587, I've reduced the number of artificially created groups to reduce repetitive warnings in https://microbiome.github.io/mia/reference/splitOn.html. These warnings ultimately stem from `addTaxonomyTree`, which is called for each split object created from the original when `update_rowTree = TRUE`. I don't think this is the best solution, perhaps these could be suppressed instead?

In addition, I've fixed some grammar mistakes here and there.