### PR TITLE
agglomerateByRank fix: empty ranks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.11.3
+Version: 1.11.4
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut"),
              email = "felix.gm.ernst@outlook.com",

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -316,7 +316,10 @@ setMethod("getTaxonomyLabels", signature = c(x = "SummarizedExperiment"),
 
     tax_ranks_non_empty <- t(as(tax_ranks_non_empty,"matrix"))
     tax_ranks_selected <- apply(tax_ranks_non_empty,1L,which)
-    if(any(lengths(tax_ranks_selected) == 0L)){
+    # Check if every row got at least some rank information from taxonomy table
+    # i.e. the info was not empty.
+    if( any(lengths(tax_ranks_selected) == 0L) || length(
+        tax_ranks_selected) == 0L){
         if(!anyDuplicated(rownames(x))){
             return(NULL)
         }


### PR DESCRIPTION
agglomerateByRanks was failing if no taxonomy info was found for rows. For example, if the intention was to agglomerate data to kingdom level and all the values in kingdom level were NA. --> Now the function returns 1 row named "NA".