### PR TITLE
Fix splitOn bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -84,5 +84,5 @@ Suggests:
 URL: https://github.com/microbiome/mia
 BugReports: https://github.com/microbiome/mia/issues
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.11.4
+Version: 1.11.5
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut"),
              email = "felix.gm.ernst@outlook.com",

--- a/NEWS
+++ b/NEWS
@@ -97,3 +97,4 @@ Changes in version 1.9.x
 Changes in version 1.11.x
 + loadFromMetaphlan: support strain rank
 + agglomerateByRank: agglomerate tree fix
++ splitOn: update rowTree fix

--- a/R/splitOn.R
+++ b/R/splitOn.R
@@ -290,10 +290,10 @@ setMethod("splitOn", signature = c(x = "TreeSummarizedExperiment"),
         if( update_rowTree ){
             # If the returned value is a list, go through all of them
             if( class(x) == "SimpleList" ){
-                x <- SimpleList(lapply(x, addTaxonomyTree))
+                x <- SimpleList(lapply(x, .agglomerate_trees))
             } else {
                 # Otherwise, the returned value is TreeSE
-                x <- addTaxonomyTree(x)
+                x <- .agglomerate_trees(x)
             }
         }
         x

--- a/man/transformAssay.Rd
+++ b/man/transformAssay.Rd
@@ -120,9 +120,10 @@ reference sample's column in returned assay when calculating alr.
 (default: \code{ref_vals = NA})}
 }}
 
-\item{pseudocount}{TRUE or FALSE, should the minimum value of \code{assay.type}
-be added to assay values. Alternatively, a numeric value specifying the value
-to be added. (default: \code{pseudocount = FALSE})}
+\item{pseudocount}{TRUE, FALSE, or a numeric value. When TRUE,
+automatically adds the minimum positive value of \code{assay.type}.
+When FALSE, does not add any pseudocount (pseudocount = 0).
+Alternatively, a user-specified numeric value can be added as pseudocount.}
 
 \item{MARGIN}{A single character value for specifying whether the
 transformation is applied sample (column) or feature (row) wise.

--- a/tests/testthat/test-4splitOn.R
+++ b/tests/testthat/test-4splitOn.R
@@ -39,6 +39,14 @@ test_that("splitOn", {
     expect_equal( rownames(list[[1]]), rownames(x) )
     expect_true( length(list) == 10 )
     
+    # Test that number of tips of updated rowTree equals number of rows for
+    # each tse in the list returned
+    list <- splitOn(x, "SampleType", update_rowTree = TRUE)
+    for (k in length(list)){
+        expect_equal( length(rowTree(list[[k]], "phylo")$tip.label), 
+                      nrow(list[[k]]) )
+    }
+    
     ################################# unsplitOn ################################
     # Test that error occurs
     expect_error( unsplitOn(x) )


### PR DESCRIPTION
After splitting the data, if `udpate_rowTree` is `TRUE`, `splitOn()` adds a new `rowTree` to all `TreeSummarizedExperiment` objects in the returned list instead of manipulating the existing `rowTree`. This PR should fix this bug (issue #494)

This PR is related to PR https://github.com/microbiome/mia/pull/487.

