### PR TITLE
Deprecate functions *_join

### DIFF
--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -104,3 +104,71 @@ loadFromHumann <- function(...) {
                             " Use 'importHUMAnN' instead."))
     importHUMAnN(...)
 }
+
+#' @rdname deprecate
+#' @export
+setGeneric("full_join", signature = c("x"),
+           function(x, ...)
+               standardGeneric("full_join"))
+
+#' @rdname deprecate
+#' @export
+setMethod("full_join", signature = c(x = "ANY"),
+            function(x, ...){
+                .Deprecated(msg = paste0("'full_join' is deprecated. ",
+                                        "Use 'mergeSEs' with 'join = full' ",
+                                        "instead."))
+                mergeSEs(x, join = "full", ...)
+            }
+)
+
+#' @rdname deprecate
+#' @export
+setGeneric("inner_join", signature = c("x"),
+           function(x, ...)
+               standardGeneric("inner_join"))
+
+#' @rdname deprecate
+#' @export
+setMethod("inner_join", signature = c(x = "ANY"),
+            function(x, ...){
+                .Deprecated(msg = paste0("'inner_join' is deprecated. ",
+                                        "Use 'mergeSEs' with 'join = inner' ",
+                                        "instead."))
+                mergeSEs(x, join = "inner", ...)
+            }
+)
+
+#' @rdname deprecate
+#' @export
+setGeneric("left_join", signature = c("x"),
+           function(x, ...)
+               standardGeneric("left_join"))
+
+#' @rdname deprecate
+#' @export
+setMethod("left_join", signature = c(x = "ANY"),
+          function(x, ...){
+              .Deprecated(msg = paste0("'left_join' is deprecated. ",
+                                        "Use 'mergeSEs' with 'join = left' ",
+                                        "instead."))
+              mergeSEs(x, join = "left", ...)
+          }
+)
+
+#' @rdname deprecate
+#' @export
+setGeneric("right_join", signature = c("x"),
+           function(x, ...)
+               standardGeneric("right_join"))
+
+#' @rdname deprecate
+#' @export
+setMethod("right_join", signature = c(x = "ANY"),
+            function(x, ...){
+                .Deprecated(msg = paste0("'right_join' is deprecated. ",
+                                        "Use 'mergeSEs' with 'join = right' ",
+                                        "instead."))
+                mergeSEs(x, join = "right", ...)
+            }
+)

--- a/R/mergeSEs.R
+++ b/R/mergeSEs.R
@@ -75,9 +75,6 @@
 #'   \item{\code{right} -- all the features of the second object}
 #' }
 #' 
-#' You can also doe e.g., a full join by using a function \code{full_join} which is 
-#' an alias for \code{mergeSEs}. Also other joining methods have dplyr-like aliases.
-#' 
 #' The output depends on the input. If the input contains \code{SummarizedExperiment}
 #' object, then the output will be \code{SummarizedExperiment}. When all the input
 #' objects belong to \code{TreeSummarizedExperiment}, the output will be 
@@ -121,13 +118,11 @@
 #' tse_temp <- mergeSEs(tse[1:10, 1:10], tse[5:100, 11:20], join = "left")
 #' tse_temp
 #' 
-#' # You can also do a left_join by using alias "left_join"
-#' tse_temp <- left_join(tse[1:10, 1:10], tse[5:100, 11:20])
-#' 
 #' # If your objects contain samples that describe one and same sample,
 #' # you can collapse equally named samples to one by specifying 'collapse_samples'
-#' tse_temp <- inner_join(list(tse[1:10, 1], tse[1:20, 1], tse[1:5, 1]), 
-#'                        collapse_samples = TRUE)
+#' tse_temp <- mergeSEs(list(tse[1:10, 1], tse[1:20, 1], tse[1:5, 1]), 
+#'                        collapse_samples = TRUE,
+#'                        join = "inner")
 #' tse_temp
 #' 
 #' # Merge all available assays
@@ -258,70 +253,6 @@ setMethod("mergeSEs", signature = c(x = "list"),
               # Call the function for list
               mergeSEs(x, ...)
           }
-)
-
-################################# full_join ####################################
-
-#' @rdname mergeSEs
-#' @export
-setGeneric("full_join", signature = c("x"),
-    function(x, ...)
-        standardGeneric("full_join"))
-
-#' @rdname mergeSEs
-#' @export
-setMethod("full_join", signature = c(x = "ANY"),
-    function(x, ...){
-        mergeSEs(x, join = "full", ...)
-    }
-)
-
-################################# inner_join ###################################
-
-#' @rdname mergeSEs
-#' @export
-setGeneric("inner_join", signature = c("x"),
-    function(x, ...)
-        standardGeneric("inner_join"))
-
-#' @rdname mergeSEs
-#' @export
-setMethod("inner_join", signature = c(x = "ANY"),
-    function(x, ...){
-        mergeSEs(x, join = "inner", ...)
-    }
-)
-
-################################# left_join ####################################
-
-#' @rdname mergeSEs
-#' @export
-setGeneric("left_join", signature = c("x"),
-    function(x, ...)
-        standardGeneric("left_join"))
-
-#' @rdname mergeSEs
-#' @export
-setMethod("left_join", signature = c(x = "ANY"),
-    function(x, ...){
-        mergeSEs(x, join = "left", ...)
-    }
-)
-
-################################# right_join ###################################
-
-#' @rdname mergeSEs
-#' @export
-setGeneric("right_join", signature = c("x"),
-    function(x, ...)
-        standardGeneric("right_join"))
-
-#' @rdname mergeSEs
-#' @export
-setMethod("right_join", signature = c(x = "ANY"),
-    function(x, ...){
-        mergeSEs(x, join = "right", ...)
-    }
 )
 
 ################################ HELP FUNCTIONS ################################

--- a/man/deprecate.Rd
+++ b/man/deprecate.Rd
@@ -14,6 +14,14 @@
 \alias{loadFromMothur}
 \alias{loadFromMetaphlan}
 \alias{loadFromHumann}
+\alias{full_join}
+\alias{full_join,ANY-method}
+\alias{inner_join}
+\alias{inner_join,ANY-method}
+\alias{left_join}
+\alias{left_join,ANY-method}
+\alias{right_join}
+\alias{right_join,ANY-method}
 \title{These functions will be deprecated. Please use other functions instead.}
 \usage{
 cluster(x, ...)
@@ -39,6 +47,22 @@ loadFromMothur(...)
 loadFromMetaphlan(...)
 
 loadFromHumann(...)
+
+full_join(x, ...)
+
+\S4method{full_join}{ANY}(x, ...)
+
+inner_join(x, ...)
+
+\S4method{inner_join}{ANY}(x, ...)
+
+left_join(x, ...)
+
+\S4method{left_join}{ANY}(x, ...)
+
+right_join(x, ...)
+
+\S4method{right_join}{ANY}(x, ...)
 }
 \arguments{
 \item{x}{A

--- a/man/mergeSEs.Rd
+++ b/man/mergeSEs.Rd
@@ -5,14 +5,6 @@
 \alias{mergeSEs,SimpleList-method}
 \alias{mergeSEs,SummarizedExperiment-method}
 \alias{mergeSEs,list-method}
-\alias{full_join}
-\alias{full_join,ANY-method}
-\alias{inner_join}
-\alias{inner_join,ANY-method}
-\alias{left_join}
-\alias{left_join,ANY-method}
-\alias{right_join}
-\alias{right_join,ANY-method}
 \title{Merge SE objects into single SE object.}
 \usage{
 mergeSEs(x, ...)
@@ -32,22 +24,6 @@ mergeSEs(x, ...)
 \S4method{mergeSEs}{SummarizedExperiment}(x, y = NULL, ...)
 
 \S4method{mergeSEs}{list}(x, ...)
-
-full_join(x, ...)
-
-\S4method{full_join}{ANY}(x, ...)
-
-inner_join(x, ...)
-
-\S4method{inner_join}{ANY}(x, ...)
-
-left_join(x, ...)
-
-\S4method{left_join}{ANY}(x, ...)
-
-right_join(x, ...)
-
-\S4method{right_join}{ANY}(x, ...)
 }
 \arguments{
 \item{x}{a \code{\link{SummarizedExperiment}} object or a list of
@@ -128,9 +104,6 @@ to choose which rows are included.
 \item{\code{left} -- all the features of the first object}
 \item{\code{right} -- all the features of the second object}
 }
-
-You can also doe e.g., a full join by using a function \code{full_join} which is
-an alias for \code{mergeSEs}. Also other joining methods have dplyr-like aliases.
 
 The output depends on the input. If the input contains \code{SummarizedExperiment}
 object, then the output will be \code{SummarizedExperiment}. When all the input

--- a/tests/testthat/test-2mergeSEs.R
+++ b/tests/testthat/test-2mergeSEs.R
@@ -303,32 +303,6 @@ test_that("mergeSEs", {
                        join = "left")
     expect_true(class(tse) == "TreeSummarizedExperiment")
     
-    # Test dplyr-like aliases
-    tse_test1 <- mergeSEs(x = tse[1:28, 1:3], 
-                         y = tse1[23, 1:5], 
-                         join = "full")
-    tse_test2 <- full_join(x = tse[1:28, 1:3], 
-                           y = tse1[23, 1:5])
-    expect_equal(tse_test1, tse_test2)
-    tse_test1 <- mergeSEs(x = tse[1:28, 1:3], 
-                         y = tse1[23, 1:5], 
-                         join = "left")
-    tse_test2 <- left_join(x = tse[1:28, 1:3], 
-                           y = tse1[23, 1:5])
-    expect_equal(tse_test1, tse_test2)
-    tse_test1 <- suppressWarnings( 
-        mergeSEs(x = list(tse1[1:28, 1:3], tse1[23, 1:5], tse1[2:4, ]), 
-                         join = "inner")
-    )
-    tse_test2 <- suppressWarnings( 
-        inner_join(x = list(tse1[1:28, 1:3], tse1[23, 1:5], tse1[2:4, ]) )
-    )
-    expect_equal(tse_test1, tse_test2)
-    tse_test1 <- mergeSEs(x = list(tse1[1:28, 1:3], tse1[23, 1:5]), 
-                         join = "right")
-    tse_test2 <- right_join(x = list(tse1[1:28, 1:3], tse1[23, 1:5]) )
-    expect_equal(tse_test1, tse_test2)
-    
     # Test collapse_samples
     tse_test <- mergeSEs(x = tse[1:28, 1:3], 
                          y = tse[23, 1:5], 


### PR DESCRIPTION
This PR deprecates following functions :

- `full_join`
- `inner_join`
- `left_join`
- `right_join`

These functions were aliases for `mergeSEs` with parameter `join`, thus they do not need to be replaced.