### PR TITLE
agglomerateByRank: bugfix related to agglomeration non-existing tree

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.13.3
+Version: 1.13.4
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut"),
              email = "felix.gm.ernst@outlook.com",

--- a/NEWS
+++ b/NEWS
@@ -117,3 +117,4 @@ Changes in version 1.13.x
 + Added new functions getMediation and addMediation
 + replace getExperiment* and testExperiment* functions with getCrossAssociation
 + Replace mergeRows and mergeCols with new function agglomerateByVariable
++ agglomerateByRank: bugfix related to agglomeration of non-existing tree

--- a/R/agglomerate.R
+++ b/R/agglomerate.R
@@ -371,10 +371,9 @@ setMethod(
                 }
                 # Agglomerate data
                 x <- callNextMethod(x, ...)
-                # Agglomerate also tree, if the data includes only one
-                # rowTree --> otherwise it is not possible to agglomerate
-                # since all rownames are not found from individual tree.
-                if(agglomerate.tree){
+                # Agglomerate also trees if user has specified and if there
+                # are trees available
+                if( agglomerate.tree && !is.null(x@rowTree) ){
                     x <- .agglomerate_trees(x)
                 }
                 x


### PR DESCRIPTION
If user has specified to agglomerate tree and there are no trees, rowTree() slot of TreeSE is list after agglomeration. It should be NULL. This led to an error.