### PR TITLE
add informative error message for strictly-negative values in rarefyAssay

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.13.19
+Version: 1.13.20
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut"),
              email = "felix.gm.ernst@outlook.com",

--- a/NEWS
+++ b/NEWS
@@ -136,3 +136,4 @@ Changes in version 1.13.x
 + Fix bug in mergeFeaturesByPrevalence
 + new aliases calculateDPCoA to getDPCoA, calculateNMDS to getNMDS, calculateRDA to getRDA, 
 calculateCCA to getCCA
++ add informative error message in rarefyAssay on assays with strictly-negative values 

--- a/R/rarefyAssay.R
+++ b/R/rarefyAssay.R
@@ -125,14 +125,14 @@ setMethod("rarefyAssay", signature = c(x = "SummarizedExperiment"),
               if(!.is_non_empty_string(name) ||
                  name == assay.type){
                   stop("'name' must be a non-empty single character value and be ",
-                       "different from `assay.type`.",
-                       call. = FALSE)
+                      "different from `assay.type`.",
+                      call. = FALSE)
               }
               #set.seed(seed)
               # Make sure min_size is of length 1.
               if(length(min_size) > 1){
                   stop("`min_size` had more than one value. ", 
-                       "Specifiy a single integer value.", call. = FALSE)
+                      "Specifiy a single integer value.", call. = FALSE)
                   min_size <- min_size[1]    
               }
               if(!is.numeric(min_size) || 
@@ -146,7 +146,7 @@ setMethod("rarefyAssay", signature = c(x = "SummarizedExperiment"),
                   # Return NULL, if no samples were found after subsampling
                   if( !any(!colnames(x) %in% rmsams) ){
                       stop("No samples were found after subsampling.",
-                           call. = FALSE)
+                          call. = FALSE)
                   }
                   if(verbose){
                       message(length(rmsams), " samples removed ",
@@ -174,7 +174,6 @@ setMethod("rarefyAssay", signature = c(x = "SummarizedExperiment"),
               return(newtse)
           }
 )
-
 
 ## Modified Sub sampling function from phyloseq internals
 .subsample_assay <- function(x, min_size, replace){

--- a/R/rarefyAssay.R
+++ b/R/rarefyAssay.R
@@ -108,6 +108,10 @@ setMethod("rarefyAssay", signature = c(x = "SummarizedExperiment"),
                   warning("assay contains non-integer values. Only counts table ",
                           "is applicable...")
               }
+              if(any(assay(x, assay.type) < 0)){
+                  stop("assay contains strictly-negative values. Only counts ",
+                       "table is applicable...")
+              }
               if(!is.logical(verbose)){
                   stop("`verbose` has to be logical i.e. TRUE or FALSE")
               }

--- a/R/rarefyAssay.R
+++ b/R/rarefyAssay.R
@@ -132,7 +132,7 @@ setMethod("rarefyAssay", signature = c(x = "SummarizedExperiment"),
               # Make sure min_size is of length 1.
               if(length(min_size) > 1){
                   stop("`min_size` had more than one value. ", 
-                      "Specifiy a single integer value.", call. = FALSE)
+                      "Specify a single integer value.", call. = FALSE)
                   min_size <- min_size[1]    
               }
               if(!is.numeric(min_size) || 

--- a/R/rarefyAssay.R
+++ b/R/rarefyAssay.R
@@ -106,18 +106,20 @@ setMethod("rarefyAssay", signature = c(x = "SummarizedExperiment"),
               .check_assay_present(assay.type, x)
               if(any(assay(x, assay.type) %% 1 != 0)){
                   warning("assay contains non-integer values. Only counts table ",
-                          "is applicable...")
+                          "is applicable...", call. = FALSE)
               }
               if(any(assay(x, assay.type) < 0)){
                   stop("assay contains strictly-negative values. Only counts ",
-                       "table is applicable...")
+                      "table is applicable...", call. = FALSE)
               }
               if(!is.logical(verbose)){
-                  stop("`verbose` has to be logical i.e. TRUE or FALSE")
+                  stop("`verbose` has to be logical i.e. TRUE or FALSE", 
+                      call. = FALSE)
               }
             
               if(!is.logical(replace)){
-                  stop("`replace` has to be logical i.e. TRUE or FALSE")
+                  stop("`replace` has to be logical i.e. TRUE or FALSE",
+                      call. = FALSE)
               } 
               # Check name
               if(!.is_non_empty_string(name) ||
@@ -130,12 +132,13 @@ setMethod("rarefyAssay", signature = c(x = "SummarizedExperiment"),
               # Make sure min_size is of length 1.
               if(length(min_size) > 1){
                   stop("`min_size` had more than one value. ", 
-                       "Specifiy a single integer value.")
+                       "Specifiy a single integer value.", call. = FALSE)
                   min_size <- min_size[1]    
               }
               if(!is.numeric(min_size) || 
                  as.integer(min_size) != min_size && min_size <= 0){
-                  stop("min_size needs to be a positive integer value.")
+                  stop("min_size needs to be a positive integer value.",
+                      call. = FALSE)
               }
               # get samples with less than min number of reads
               if(min(colSums2(assay(x, assay.type))) < min_size){


### PR DESCRIPTION
Assays with strictly-negative values are not handled by `rarefyAssay`.
```
data(GlobalPatterns)
tse <- GlobalPatterns
matrix <- assay(tse)
matrix[1,1] <- -1
assay(tse) <- matrix
rarefyAssay(tse)
```
>Error in sample.int(length(x), size, replace, prob) : 
  negative probability

This PR adds an informative error message.
