### PR TITLE
fix addDominant arguments and tests

### DIFF
--- a/R/getDominant.R
+++ b/R/getDominant.R
@@ -77,8 +77,8 @@ NULL
 #' @export
 setGeneric("getDominant",signature = c("x"),
            function(x, assay.type = assay_name, assay_name = "counts", 
-                    rank = NULL, other.name = "Other", n = NULL, 
-                    complete = TRUE, ...)
+                    rank = NULL, other.name = "Other", n = NULL, complete = TRUE, 
+                    onRankOnly = TRUE,...)
                standardGeneric("getDominant"))
 
 #' @rdname getDominant
@@ -86,7 +86,8 @@ setGeneric("getDominant",signature = c("x"),
 #' @export
 setMethod("getDominant", signature = c(x = "SummarizedExperiment"),
     function(x, assay.type = assay_name, assay_name = "counts", 
-             rank = NULL, other.name = "Other", n = NULL, complete = TRUE, ...){
+             rank = NULL, other.name = "Other", n = NULL, complete = TRUE, 
+             onRankOnly = TRUE,...){
         # Input check
         # Check assay.type
         .check_assay_present(assay.type, x)
@@ -101,7 +102,7 @@ setMethod("getDominant", signature = c(x = "SummarizedExperiment"),
         # If "rank" is not NULL, species are aggregated according to the
         # taxonomic rank that is specified by user.
         if(!is.null(rank)){
-            x <- agglomerateByRank(x, rank, ...)
+            x <- agglomerateByRank(x, rank, onRankOnly,...)
             mat <- assay(x, assay.type)
         } # Otherwise, if "rank" is NULL, abundances are stored without ranking
         else {
@@ -167,14 +168,15 @@ setMethod("getDominant", signature = c(x = "SummarizedExperiment"),
 #' @rdname getDominant
 #' @export
 setGeneric("addDominant", signature = c("x"),
-           function(x, name = "dominant_taxa", other.name = "Other", n = NULL, ...)
+           function(x, rank = NULL, name = "dominant_taxa", other.name = "Other", 
+                    n = NULL, complete = TRUE, onRankOnly = TRUE, ...)
                standardGeneric("addDominant"))
 
 #' @rdname getDominant
 #' @export
 setMethod("addDominant", signature = c(x = "SummarizedExperiment"),
-    function(x, name = "dominant_taxa", other.name = "Other", n = NULL, 
-             complete = FALSE, ...) {
+    function(x, rank = NULL, name = "dominant_taxa", other.name = "Other", 
+             n = NULL, complete = TRUE, onRankOnly = TRUE, ...) {
         # name check
         if(!.is_non_empty_string(name)){
             stop("'name' must be a non-empty single character value.",
@@ -186,7 +188,8 @@ setMethod("addDominant", signature = c(x = "SummarizedExperiment"),
                  call. = FALSE)
         }
         dom.taxa <- getDominant(x, other.name = other.name, n = n, 
-                                              complete = complete, ...)
+                                complete = complete, rank = rank,
+                                onRankOnly = onRankOnly, ...)
         # Add list into colData if there are multiple dominant taxa
         if(length(unique(names(dom.taxa))) < length(names(dom.taxa))) {
             # Store order

--- a/R/getDominant.R
+++ b/R/getDominant.R
@@ -77,8 +77,8 @@ NULL
 #' @export
 setGeneric("getDominant",signature = c("x"),
            function(x, assay.type = assay_name, assay_name = "counts", 
-                    rank = NULL, other.name = "Other", n = NULL, complete = TRUE, 
-                    onRankOnly = TRUE,...)
+                    rank = NULL, other.name = "Other", n = NULL, 
+                    complete = TRUE, ...)
                standardGeneric("getDominant"))
 
 #' @rdname getDominant
@@ -86,8 +86,7 @@ setGeneric("getDominant",signature = c("x"),
 #' @export
 setMethod("getDominant", signature = c(x = "SummarizedExperiment"),
     function(x, assay.type = assay_name, assay_name = "counts", 
-             rank = NULL, other.name = "Other", n = NULL, complete = TRUE, 
-             onRankOnly = TRUE,...){
+             rank = NULL, other.name = "Other", n = NULL, complete = TRUE, ...){
         # Input check
         # Check assay.type
         .check_assay_present(assay.type, x)
@@ -102,7 +101,7 @@ setMethod("getDominant", signature = c(x = "SummarizedExperiment"),
         # If "rank" is not NULL, species are aggregated according to the
         # taxonomic rank that is specified by user.
         if(!is.null(rank)){
-            x <- agglomerateByRank(x, rank, onRankOnly,...)
+            x <- agglomerateByRank(x, rank,...)
             mat <- assay(x, assay.type)
         } # Otherwise, if "rank" is NULL, abundances are stored without ranking
         else {
@@ -169,14 +168,14 @@ setMethod("getDominant", signature = c(x = "SummarizedExperiment"),
 #' @export
 setGeneric("addDominant", signature = c("x"),
            function(x, rank = NULL, name = "dominant_taxa", other.name = "Other", 
-                    n = NULL, complete = TRUE, onRankOnly = TRUE, ...)
+                    n = NULL, complete = TRUE, ...)
                standardGeneric("addDominant"))
 
 #' @rdname getDominant
 #' @export
 setMethod("addDominant", signature = c(x = "SummarizedExperiment"),
     function(x, rank = NULL, name = "dominant_taxa", other.name = "Other", 
-             n = NULL, complete = TRUE, onRankOnly = TRUE, ...) {
+             n = NULL, complete = TRUE, ...) {
         # name check
         if(!.is_non_empty_string(name)){
             stop("'name' must be a non-empty single character value.",
@@ -188,8 +187,7 @@ setMethod("addDominant", signature = c(x = "SummarizedExperiment"),
                  call. = FALSE)
         }
         dom.taxa <- getDominant(x, other.name = other.name, n = n, 
-                                complete = complete, rank = rank,
-                                onRankOnly = onRankOnly, ...)
+                                complete = complete, rank = rank,...)
         # Add list into colData if there are multiple dominant taxa
         if(length(unique(names(dom.taxa))) < length(names(dom.taxa))) {
             # Store order

--- a/man/getDominant.Rd
+++ b/man/getDominant.Rd
@@ -15,6 +15,7 @@ getDominant(
   other.name = "Other",
   n = NULL,
   complete = TRUE,
+  onRankOnly = TRUE,
   ...
 )
 
@@ -26,17 +27,29 @@ getDominant(
   other.name = "Other",
   n = NULL,
   complete = TRUE,
+  onRankOnly = TRUE,
   ...
 )
 
-addDominant(x, name = "dominant_taxa", other.name = "Other", n = NULL, ...)
-
-\S4method{addDominant}{SummarizedExperiment}(
+addDominant(
   x,
+  rank = NULL,
   name = "dominant_taxa",
   other.name = "Other",
   n = NULL,
-  complete = FALSE,
+  complete = TRUE,
+  onRankOnly = TRUE,
+  ...
+)
+
+\S4method{addDominant}{SummarizedExperiment}(
+  x,
+  rank = NULL,
+  name = "dominant_taxa",
+  other.name = "Other",
+  n = NULL,
+  complete = TRUE,
+  onRankOnly = TRUE,
   ...
 )
 }

--- a/man/getDominant.Rd
+++ b/man/getDominant.Rd
@@ -15,7 +15,6 @@ getDominant(
   other.name = "Other",
   n = NULL,
   complete = TRUE,
-  onRankOnly = TRUE,
   ...
 )
 
@@ -27,7 +26,6 @@ getDominant(
   other.name = "Other",
   n = NULL,
   complete = TRUE,
-  onRankOnly = TRUE,
   ...
 )
 
@@ -38,7 +36,6 @@ addDominant(
   other.name = "Other",
   n = NULL,
   complete = TRUE,
-  onRankOnly = TRUE,
   ...
 )
 
@@ -49,7 +46,6 @@ addDominant(
   other.name = "Other",
   n = NULL,
   complete = TRUE,
-  onRankOnly = TRUE,
   ...
 )
 }

--- a/tests/testthat/test-5dominantTaxa.R
+++ b/tests/testthat/test-5dominantTaxa.R
@@ -32,9 +32,8 @@ test_that("getDominant", {
                           "Order:Stramenopiles","Order:Stramenopiles","Order:Stramenopiles")
         names(exp.vals.two) <- exp.names.one
         expect_equal(getDominant(tse,
-                                           rank = "Genus",
-                                           onRankOnly = FALSE,
-                                           na.rm = FALSE)[1:15],
+                                  rank = "Genus",
+                                  onRankOnly = FALSE)[1:15],
                      exp.vals.two)
 
         # Check if DominantTaxa is added to coldata
@@ -43,7 +42,7 @@ test_that("getDominant", {
                      exp.vals.one)
         expect_equal(colData(addDominant(tse,
                                             rank = "Genus",
-                                            na.rm = FALSE,
+                                            onRankOnly = FALSE,
                                             name="dominant"))$dominant[1:15],
                      exp.vals.two)
         


### PR DESCRIPTION
This PR aims to fix the following failing test:
```
── Failure ('test-5dominantTaxa.R:44:9'): getDominant ──────────────────────────
colData(addDominant(tse, rank = "Genus", na.rm = FALSE, name = "dominant"))$dominant[1:15] not equal to `exp.vals.two`.
8/15 mismatches
x[1]: "Class:Thermoprotei"
y[1]: "Genus:CandidatusSolibacter"

x[2]: "Class:Thermoprotei"
y[2]: "Genus:MC18"

x[3]: "Class:Thermoprotei"
y[3]: "Class:Chloracidobacteria"

x[7]: "Class:Thermoprotei"
y[7]: "Family:Moraxellaceae"

x[12]: "Class:Thermoprotei"
y[12]: "Family:ACK-M1"
```
I added back the argument `onRankOnly` in `getDominant` and `addDominant` functions so that the user can explicitly choose, the issue was that the default value of `onRankOnly` in `agglomerateByRank` is `TRUE` so `addDominant` needed to be explicitly called with `onRankOnly = FALSE` as it was done for `getDominant`.