### PR TITLE
fix addDominant test

### DIFF
--- a/tests/testthat/test-5dominantTaxa.R
+++ b/tests/testthat/test-5dominantTaxa.R
@@ -33,8 +33,7 @@ test_that("getDominant", {
         names(exp.vals.two) <- exp.names.one
         expect_equal(getDominant(tse,
                                            rank = "Genus",
-                                           onRankOnly = FALSE,
-                                           na.rm = FALSE)[1:15],
+                                           onRankOnly = FALSE)[1:15],
                      exp.vals.two)
 
         # Check if DominantTaxa is added to coldata
@@ -42,9 +41,10 @@ test_that("getDominant", {
                                             name="dominant"))$dominant[1:15],
                      exp.vals.one)
         expect_equal(colData(addDominant(tse,
-                                            rank = "Genus",
-                                            na.rm = FALSE,
-                                            name="dominant"))$dominant[1:15],
+                                         rank = "Genus",
+                                         onRankOnly = FALSE,
+                                         name="dominant",
+                                         complete = TRUE))$dominant[1:15],
                      exp.vals.two)
         
         tse1 <- tse


### PR DESCRIPTION
This PR aims to fix the following failing test:
```
── Failure ('test-5dominantTaxa.R:44:9'): getDominant ──────────────────────────
colData(addDominant(tse, rank = "Genus", na.rm = FALSE, name = "dominant"))$dominant[1:15] not equal to `exp.vals.two`.
8/15 mismatches
x[1]: "Class:Thermoprotei"
y[1]: "Genus:CandidatusSolibacter"

x[2]: "Class:Thermoprotei"
y[2]: "Genus:MC18"

x[3]: "Class:Thermoprotei"
y[3]: "Class:Chloracidobacteria"

x[7]: "Class:Thermoprotei"
y[7]: "Family:Moraxellaceae"

x[12]: "Class:Thermoprotei"
y[12]: "Family:ACK-M1"
```
The issue was that the default value of `onRankOnly` in `agglomerateByRank` is `TRUE` so `addDominant` needed to be explicitly called with `onRankOnly = FALSE` as it was done for `getDominant`.