### PR TITLE
Deprecate z transform in transformAssay

### DIFF
--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -52,22 +52,8 @@
 #'
 #' \itemize{
 #' 
-#' \item 'alr': Additive log ratio (alr) transformation, please refer to 
-#' \code{\link[vegan:decostand]{decostand}} for details.
-#' 
-#' \item 'chi.square': Chi square transformation, please refer to 
-#' \code{\link[vegan:decostand]{decostand}} for details.
-#' 
-#' \item 'clr': Centered log ratio (clr) transformation, please refer to 
-#' \code{\link[vegan:decostand]{decostand}} for details.
-#'
-#' \item 'frequency': Frequency transformation, please refer to 
-#' \code{\link[vegan:decostand]{decostand}} for details.
-#' 
-#' \item 'hellinger':  Hellinger transformation, please refer to 
-#' \code{\link[vegan:decostand]{decostand}} for details.
-#' 
-#' \item 'log':  Logarithmic transformation, please refer to 
+#' \item \code{alr, chi.square, clr, frequency, hellinger, log, normalize, pa, rank, rclr
+#' relabundance, rrank, standardize, total}: please refer to 
 #' \code{\link[vegan:decostand]{decostand}} for details.
 #' 
 #' \item 'log10': log10 transformation can be used for reducing the skewness
@@ -81,34 +67,6 @@
 #' \deqn{log2 = \log_{2} x}{%
 #' log2 = log2(x)}
 #' where \eqn{x} is a single value of data.
-#' 
-#' \item 'normalize': Make margin sum of squares equal to one. Please refer to 
-#' \code{\link[vegan:decostand]{decostand}} for details.
-#' 
-#' \item 'pa': Transforms table to presence/absence table. Please refer to 
-#' \code{\link[vegan:decostand]{decostand}} for details.
-#'
-#' \item 'rank': Rank transformation, please refer to 
-#' \code{\link[vegan:decostand]{decostand}} for details.
-#' 
-#' \item 'rclr':  Robust clr transformation, please refer to 
-#' \code{\link[vegan:decostand]{decostand}} for details.
-#' 
-#' \item 'relabundance': Relative transformation (alias for 'total'), please refer to 
-#' \code{\link[vegan:decostand]{decostand}} for details.
-#' 
-#' \item 'rrank': Relative rank transformation, please refer to 
-#' \code{\link[vegan:decostand]{decostand}} for details.
-#' 
-#' \item 'standardize': Scale 'x' to zero mean and unit variance (alias for
-#' 'z'), please refer to \code{\link[vegan:decostand]{decostand}} for details.
-#' 
-#' \item 'total': Divide by margin total (alias for
-#' 'relabundance'), please refer to 
-#' \code{\link[vegan:decostand]{decostand}} for details.
-#' 
-#' \item 'z': Z transformation (alias for 'standardize'),
-#' please refer to \code{\link[vegan:decostand]{decostand}} for details.
 #'
 #' }
 #'
@@ -310,6 +268,10 @@ setMethod("transformAssay", signature = c(x = "SummarizedExperiment"),
     MARGIN <- ifelse(MARGIN %in% c("samples", "columns", "col", 2), 2, 1)
     # Adjust method if mia-specific alias was used
     method <- ifelse(method == "relabundance", "total", method)
+    
+    if (method == "z") {
+        .Deprecated(old="z", new="standardize", "Now 'z' is deprecated. Use 'standardize' instead.")
+    }
     method <- ifelse(method == "z", "standardize", method)
     
     # If method is ALR, vegan drops one column/sample, because it is used

--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -52,8 +52,8 @@
 #'
 #' \itemize{
 #' 
-#' \item \code{alr, chi.square, clr, frequency, hellinger, log, normalize, pa, rank, rclr
-#' relabundance, rrank, standardize, total}: please refer to 
+#' \item 'alr', 'chi.square', 'clr', 'frequency', 'hellinger', 'log', 'normalize', 'pa', 'rank', 'rclr'
+#' 'relabundance', 'rrank', 'standardize', 'total': please refer to 
 #' \code{\link[vegan:decostand]{decostand}} for details.
 #' 
 #' \item 'log10': log10 transformation can be used for reducing the skewness
@@ -270,7 +270,7 @@ setMethod("transformAssay", signature = c(x = "SummarizedExperiment"),
     method <- ifelse(method == "relabundance", "total", method)
     
     if (method == "z") {
-        .Deprecated(old="z", new="standardize", "Now 'z' is deprecated. Use 'standardize' instead.")
+        .Deprecated(old="z", new="standardize")
     }
     method <- ifelse(method == "z", "standardize", method)
     

--- a/man/transformAssay.Rd
+++ b/man/transformAssay.Rd
@@ -89,8 +89,8 @@ The available transformation methods include:
 
 \itemize{
 
-\item \code{alr, chi.square, clr, frequency, hellinger, log, normalize, pa, rank, rclr
-relabundance, rrank, standardize, total}: please refer to
+\item 'alr', 'chi.square', 'clr', 'frequency', 'hellinger', 'log', 'normalize', 'pa', 'rank', 'rclr'
+'relabundance', 'rrank', 'standardize', 'total': please refer to
 \code{\link[vegan:decostand]{decostand}} for details.
 
 \item 'log10': log10 transformation can be used for reducing the skewness

--- a/man/transformAssay.Rd
+++ b/man/transformAssay.Rd
@@ -89,22 +89,8 @@ The available transformation methods include:
 
 \itemize{
 
-\item 'alr': Additive log ratio (alr) transformation, please refer to
-\code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'chi.square': Chi square transformation, please refer to
-\code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'clr': Centered log ratio (clr) transformation, please refer to
-\code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'frequency': Frequency transformation, please refer to
-\code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'hellinger':  Hellinger transformation, please refer to
-\code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'log':  Logarithmic transformation, please refer to
+\item \code{alr, chi.square, clr, frequency, hellinger, log, normalize, pa, rank, rclr
+relabundance, rrank, standardize, total}: please refer to
 \code{\link[vegan:decostand]{decostand}} for details.
 
 \item 'log10': log10 transformation can be used for reducing the skewness
@@ -118,34 +104,6 @@ the data.
 \deqn{log2 = \log_{2} x}{%
 log2 = log2(x)}
 where \eqn{x} is a single value of data.
-
-\item 'normalize': Make margin sum of squares equal to one. Please refer to
-\code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'pa': Transforms table to presence/absence table. Please refer to
-\code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'rank': Rank transformation, please refer to
-\code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'rclr':  Robust clr transformation, please refer to
-\code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'relabundance': Relative transformation (alias for 'total'), please refer to
-\code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'rrank': Relative rank transformation, please refer to
-\code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'standardize': Scale 'x' to zero mean and unit variance (alias for
-'z'), please refer to \code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'total': Divide by margin total (alias for
-'relabundance'), please refer to
-\code{\link[vegan:decostand]{decostand}} for details.
-
-\item 'z': Z transformation (alias for 'standardize'),
-please refer to \code{\link[vegan:decostand]{decostand}} for details.
 
 }
 }


### PR DESCRIPTION
This commit does the following:
1-  Deprecates the z method in transformAssay
2- Updates the documentation to  only reference transformation methods already present in vegan::decostand.