### PR TITLE
Fix pseudocount

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.13.30
+Version: 1.13.31
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut"),
              email = "felix.gm.ernst@outlook.com",

--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -377,11 +377,14 @@ setMethod("transformAssay", signature = c(x = "SummarizedExperiment"),
             stop("The assay contains missing or negative values. ",
                  "'pseudocount' must be specified manually.", call. = FALSE)
         }
-        # If pseudocount TRUE, set it to half of non-zero minimum value, else set 
-        # it to zero.
+        # If pseudocount TRUE, set it to
+        # a) counts: non-zero minimum value
+        # b) non-integers: half of non-zero minimum value
+        # else set it to zero.
         # Get min value
-        value <- min(mat[mat>0]) 
-        pseudocount <- ifelse(pseudocount, value / 2, 0)
+        value <- min(mat[mat>0])
+        value <- ifelse(all(mat %% 1 == 0), value, value / 2)
+        pseudocount <- ifelse(pseudocount, value, 0)
         # Report pseudocount if positive value
         if ( pseudocount > 0 ){
             message("A pseudocount of ", pseudocount, " was applied.")

--- a/tests/testthat/test-5transformCounts.R
+++ b/tests/testthat/test-5transformCounts.R
@@ -222,7 +222,16 @@ test_that("transformAssay", {
         expect_equal(assay(tse, "pseudo_true"), assay(tse, "pseudo_min"), check.attributes = FALSE)
         expect_equal(assay(tse, "pseudo_false"), assay(tse, "pseudo_zero"), check.attributes = FALSE)
         expect_false(all(assay(tse, "pseudo_true") == assay(tse, "pseudo_false")))
-
+        
+        # For non-integer values, the default pseudocount should be half of the
+        # minimum value
+        tse <- transformAssay(
+            tse, assay.type = "relabundance", method = "clr",
+            pseudocount = TRUE)
+        test <- attr(assay(tse, "clr"), "parameters")[["pseudocount"]]
+        ref <- assay(tse, "relabundance")
+        ref <- min(ref[ref > 0])/2
+        expect_equal(test, ref)
         ############################# NAMES ####################################
         # Tests that samples have correct names
         expect_equal(colnames(assays(transformAssay(tse, assay.type = "relabundance",

--- a/tests/testthat/test-5transformCounts.R
+++ b/tests/testthat/test-5transformCounts.R
@@ -215,7 +215,7 @@ test_that("transformAssay", {
         tse <- transformAssay(tse, method = "relabundance", pseudocount = TRUE, name = "pseudo_true")
         tse <- transformAssay(
             tse, method = "relabundance", name = "pseudo_min",
-            pseudocount = (min(assay(tse, "counts")[assay(tse, "counts") > 0])) / 2,
+            pseudocount = (min(assay(tse, "counts")[assay(tse, "counts") > 0])),
         )
         tse <- transformAssay(tse, method = "relabundance", pseudocount = FALSE, name = "pseudo_false")
         tse <- transformAssay(tse, method = "relabundance", pseudocount = 0, name = "pseudo_zero")


### PR DESCRIPTION
Pseudocount was set to half of the minimum value by default. However, usually pseudocount is 1 when the matrix contains counts.

Now pseudocount is minimum value when counts, otherwise half of the minimum value