### PR TITLE
Fix addAlpha

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.13.31
+Version: 1.13.32
 Authors@R:
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut"),
              email = "felix.gm.ernst@outlook.com",

--- a/R/addAlpha.R
+++ b/R/addAlpha.R
@@ -490,7 +490,7 @@ setMethod("addAlpha", signature = c(x = "SummarizedExperiment"),
         }
         # Check if index exists. For each index input, detect it and get
         # information (e.g. internal function) to calculate the index.
-        index <- .get_indices(index, name, x)
+        index <- .get_indices(index, name, x, ...)
         ############################ Input check end ###########################
         # Looping over the vector of indices to be estimated
         for( i in seq_len(nrow(index)) ){
@@ -515,7 +515,7 @@ setMethod("addAlpha", signature = c(x = "SummarizedExperiment"),
 ################################ HELP FUNCTIONS ################################
 
 # Search alpha diversity index that user wants to calculate.
-.get_indices <- function(index, name, x){
+.get_indices <- function(index, name, x, tree = NULL, ...){
     # Initialize list for supported indices
     supported <- list()
     # Supported diversity indices
@@ -574,8 +574,9 @@ setMethod("addAlpha", signature = c(x = "SummarizedExperiment"),
             call. = FALSE)
     }
     # Faith index is available only for TreeSE with rowTree
-    if( "faith" %in% detected[["index"]] &&
-            !(is(x, "TreeSummarizedExperiment") && !is.null(rowTree(x))) ){
+    tse_with_tree <- (is(x, "TreeSummarizedExperiment") &&
+        !is.null(rowTree(x))) || !is.null(tree)
+    if( "faith" %in% detected[["index"]] && !tse_with_tree ){
         # Drop faith index from indices being calculated
         detected <- detected[!detected[["index"]] %in% c("faith"), ]
         # If there are still other indices being calculated, give warning.
@@ -583,7 +584,7 @@ setMethod("addAlpha", signature = c(x = "SummarizedExperiment"),
         # calculate.
         FUN <- if( nrow(detected) == 0 ) stop else warning
         FUN("'faith' index can be calculated only for TreeSE with rowTree(x) ",
-            "populated.", call. = FALSE)
+            "populated or with 'tree' provided separately.", call. = FALSE)
     }
     # Check if there are indices left
     return(detected)

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -1031,7 +1031,7 @@ setMethod(
     "estimateEvenness", signature = c(x = "ANY"), function(x, ...){
         .Deprecated(msg = paste0(
             "'estimateEvenness' is deprecated. Use 'addAlpha' instead."))
-        .estimate_evenness(x, ...)
+        addAlpha(x, ...)
     }
 )
 
@@ -1048,7 +1048,7 @@ setMethod(
     function(x, ...){
         .Deprecated(msg = paste0(
           "'estimateRichness' is deprecated. Use 'addAlpha' instead."))
-        .estimate_richness(x, ...)
+        addAlpha(x, ...)
     }
 )
 
@@ -1064,7 +1064,7 @@ setMethod(
     "estimateDiversity", signature = c(x = "ANY"), function(x, ...){
         .Deprecated(msg = paste0(
             "'estimateDiversity' is deprecated. Use 'addAlpha' instead."))
-        .estimate_diversity(x, ...)
+        addAlpha(x, ...)
     }
 )
 
@@ -1081,7 +1081,7 @@ setMethod(
     function(x, ...){
         .Deprecated(msg = paste0(
           "'estimateFaith' is deprecated. Use 'addAlpha' instead."))
-        .estimate_faith(x, ...)
+        addAlpha(x, ...)
     }
 )
 
@@ -1098,5 +1098,5 @@ setMethod(
     function(x, ...){
         .Deprecated(msg = paste0(
           "'estimateDominance' is deprecated. Use 'addAlpha' instead."))
-        .estimate_dominance(x, ...)
+        addAlpha(x, ...)
     })

--- a/R/estimateDominance.R
+++ b/R/estimateDominance.R
@@ -230,44 +230,42 @@ setGeneric(
         ntaxa = 1, aggregate = TRUE, name = index, BPPARAM = SerialParam(), ...)
     standardGeneric(".estimate_dominance"))
 
-setMethod(".estimate_dominance", signature = c(x = "SummarizedExperiment"),
-    function(
+.estimate_dominance <- function(
         x, assay.type = assay_name, assay_name = "counts",
         index = c(
             "absolute", "dbp", "core_abundance", "gini", "dmn", "relative",
             "simpson_lambda"),
         ntaxa = 1, aggregate = TRUE, name = index, BPPARAM = SerialParam(),
         ...){
-        # Input check
-        # Check assay.type
-        .check_assay_present(assay.type, x)
-        # Check indices
-        index <- match.arg(index, several.ok = TRUE)
-        if(!.is_non_empty_character(name) || length(name) != length(index)){
-            stop("'name' must be a non-empty character value and have the 
-                 same length as 'index'",
-                 call. = FALSE)
-        }
-
-        # Check aggregate
-        if(!.is_a_bool(aggregate)){
-            stop("'aggregate' must be TRUE or FALSE.", call. = FALSE)
-        }
-
-        # Calculates dominance indices
-        dominances <- BiocParallel::bplapply(
-            index,
-            FUN = .get_dominance_values,
-            mat = assay(x,assay.type),
-            ntaxa = ntaxa,
-            aggregate = aggregate,
-            BPPARAM = BPPARAM)
-
-        # Add dominance indices to colData
-        x <- .add_values_to_colData(x, dominances, name)
-        return(x)
+    # Input check
+    # Check assay.type
+    .check_assay_present(assay.type, x)
+    # Check indices
+    index <- match.arg(index, several.ok = TRUE)
+    if(!.is_non_empty_character(name) || length(name) != length(index)){
+        stop("'name' must be a non-empty character value and have the 
+             same length as 'index'",
+             call. = FALSE)
     }
-)
+
+    # Check aggregate
+    if(!.is_a_bool(aggregate)){
+        stop("'aggregate' must be TRUE or FALSE.", call. = FALSE)
+    }
+
+    # Calculates dominance indices
+    dominances <- BiocParallel::bplapply(
+        index,
+        FUN = .get_dominance_values,
+        mat = assay(x,assay.type),
+        ntaxa = ntaxa,
+        aggregate = aggregate,
+        BPPARAM = BPPARAM)
+
+    # Add dominance indices to colData
+    x <- .add_values_to_colData(x, dominances, name)
+    return(x)
+}
 
 #---------------------------Help functions--------------------------------------
 

--- a/R/estimateEvenness.R
+++ b/R/estimateEvenness.R
@@ -121,32 +121,27 @@
 #'
 NULL
 
-setGeneric(".estimate_evenness",signature = c("x"), function(x, ...)
-    standardGeneric(".estimate_evenness"))
-
-setMethod(
-    ".estimate_evenness", signature = c(x = "SummarizedExperiment"),
-    function(
+.estimate_evenness <- function(
         x, assay.type = assay_name, assay_name = "counts",
         index = c("camargo", "pielou", "simpson_evenness", "evar", "bulla"),
         name = index, ..., BPPARAM = SerialParam()){
-        # input check
-        index <- match.arg(index, several.ok = TRUE)
-        if(!.is_non_empty_character(name) || length(name) != length(index)){
-            stop("'name' must be a non-empty character value and have the ",
-                "same length as 'index'.",
-                call. = FALSE)
-        }
-        .check_assay_present(assay.type, x)
-        #
-        vnss <- BiocParallel::bplapply(index,
-                                        .get_evenness_values,
-                                        mat = assay(x, assay.type),
-                                        BPPARAM = BPPARAM, ...)
-        x <- .add_values_to_colData(x, vnss, name)
-        return(x)
+    # input check
+    index <- match.arg(index, several.ok = TRUE)
+    if(!.is_non_empty_character(name) || length(name) != length(index)){
+        stop("'name' must be a non-empty character value and have the ",
+            "same length as 'index'.",
+            call. = FALSE)
     }
-)
+    .check_assay_present(assay.type, x)
+    #
+    vnss <- BiocParallel::bplapply(
+        index,
+        .get_evenness_values,
+        mat = assay(x, assay.type),
+        BPPARAM = BPPARAM, ...)
+    x <- .add_values_to_colData(x, vnss, name)
+    return(x)
+}
 
 .calc_bulla_evenness <- function(mat) {
     # Species richness (number of species)

--- a/R/estimateRichness.R
+++ b/R/estimateRichness.R
@@ -191,14 +191,7 @@
 #'
 NULL
 
-setGeneric(".estimate_richness", signature = c("x"), function(
-    x, assay.type = assay_name, assay_name = "counts",
-    index = c("ace", "chao1", "hill", "observed"), name = index,
-    detection = 0, BPPARAM = SerialParam(), ...)
-        standardGeneric(".estimate_richness"))
-
-setMethod(
-    ".estimate_richness", signature = c(x = "SummarizedExperiment"), function(
+.estimate_richness <- function(
         x, assay.type = assay_name, assay_name = "counts",
         index = c("ace", "chao1", "hill", "observed"), name = index,
         detection = 0, BPPARAM = SerialParam(), ...){
@@ -222,8 +215,7 @@ setMethod(
     # Add richness indices to colData
     x <- .add_values_to_colData(x, richness, name)
     return(x)
-    }
-)
+}
 
 .calc_observed <- function(mat, detection, ...){
     # vegan::estimateR(t(mat))["S.obs",]

--- a/tests/testthat/test-0diversity.R
+++ b/tests/testthat/test-0diversity.R
@@ -89,7 +89,7 @@ test_that("diversity estimates", {
     rownames(se) <- rownames(tse)
     
     # Calculates "faith" TSE
-    tse_only <- .estimate_faith(tse)
+    tse_only <- addAlpha(tse, index = "faith")
     
     # tse_only should be TSE object
     expect_true(class(tse_only)== "TreeSummarizedExperiment")
@@ -97,7 +97,7 @@ test_that("diversity estimates", {
     expect_equal(colnames(colData(tse_only)), c(colnames(colData(tse)), "faith"))
     
     # Calculates "faith" TSE + TREE
-    tse_tree <- .estimate_faith(tse, tree = rowTree(tse))
+    tse_tree <- addAlpha(tse, index = "faith", tree = rowTree(tse))
     
     # tse_tree should be TSE object
     expect_true(class(tse_tree)== "TreeSummarizedExperiment")
@@ -107,7 +107,7 @@ test_that("diversity estimates", {
     
     
     # Calculates "faith" SE + TREE
-    se_tree <- .estimate_faith(se, tree = rowTree(tse))
+    se_tree <- addAlpha(se, index = "faith", tree = rowTree(tse))
     
     # se_tree should be SE object
     expect_true(class(se_tree)== "SummarizedExperiment")
@@ -115,13 +115,13 @@ test_that("diversity estimates", {
     expect_equal(colnames(colData(se_tree)), c(colnames(colData(se)), "faith"))
     
     # Expect error
-    expect_error(.estimate_diversity(tse, index = "faith", tree.name = "test"))
-    expect_warning(.estimate_diversity(tse, index = c("shannon", "faith"), tree.name = "test"))
+    expect_error(addAlpha(tse, index = "faith", tree.name = "test"))
+    expect_error(addAlpha(tse, index = c("shannon", "faith"), tree.name = "test"))
     
     data(GlobalPatterns, package="mia")
     data(esophagus, package="mia")
     tse <- mergeSEs(GlobalPatterns, esophagus,  join = "full", assay.type = "counts")
-    expect_warning(.estimate_diversity(tse, index = c("shannon", "faith"), 
+    expect_error(.estimate_diversity(tse, index = c("shannon", "faith"), 
                                      tree.name = "phylo.1", assay.type="counts"))
     expect_error(.estimate_diversity(tse, index = c("faith"), 
                                    tree.name = "test"))

--- a/tests/testthat/test-0diversity.R
+++ b/tests/testthat/test-0diversity.R
@@ -140,10 +140,12 @@ test_that("diversity estimates", {
         245.1008, 127.2336, 167.7246, 155.5872, 142.3473, 197.6823, 197.2321,
         124.6510, 121.2056, 179.9377, 140.8096, 126.5695)
     tse <- GlobalPatterns
-    res <- .estimate_faith(tse)$faith
+    res <- .estimate_faith(tse, assay(tse), rowTree(tse))
     expect_equal(res, picante_res, tolerance=1e-5)
     # Check only tips paramater
-    expect_error(.estimate_faith(tse, only.tips = 1))
-    expect_error(.estimate_faith(tse, only.tips = "TRUE"))
-    expect_error(.estimate_faith(tse, only.tips = c(TRUE, FALSE)))
+    expect_error(.estimate_faith(tse, assay(tse), rowTree(tse), only.tips = 1))
+    expect_error(.estimate_faith(
+        tse, assay(tse), rowTree(tse), only.tips = "TRUE"))
+    expect_error(.estimate_faith(
+        tse, assay(tse), rowTree(tse), only.tips = c(TRUE, FALSE)))
     })


### PR DESCRIPTION
addAlpha was failing with the following commands

```
data("GlobalPatterns")

tse <- GlobalPatterns

# This was not working
addAlpha(tse, index = "faith") |> colData()
addAlpha(tse, index = "faith", tree = rowTree(tse) ) |> colData()

se <- tse
rowTree(se) <- NULL
addAlpha(se, index = "faith", tree = rowTree(tse) ) |> colData()
addAlpha(se, index = "faith") |> colData()

se <- as(tse, "SummarizedExperiment")
rownames(se) <- rownames(tse)
addAlpha(se, index = "faith", tree = rowTree(tse) ) |> colData()
addAlpha(se, index = "faith") |> colData()
```

Now it is working. I also ensured that deprecated estimate* functions work after modifications.

The problem was related to calling .estimate_faith which was generic function. First TreeSE version of .estimate_faith was called and then the TreeSE version called SE version. However, there was missmatch, and (Tree)SE + phylo was not detected which caused an error.

The code -- especially faith calculation -- was very complex since both estimateDiversity (.estimate_diversity) and estimateFaith (.estimate_faith) were exported functions previously. As now all alpha measures are calculated with addAlpha, we can remove functionality that was related to exporting the function For instance, estimateFaith needed to work alone before; now the function is called from addAlpha -->.estimate_diversity, so it does not need all the functionality that exported functions need to have.