### PR TITLE
Fix alpha rarefaction

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.15.23
+Version: 1.15.24
 Authors@R:
     c(person(given = "Tuomas", family = "Borman", role = c("aut", "cre"),
              email = "tuomas.v.borman@utu.fi",

--- a/R/addAlpha.R
+++ b/R/addAlpha.R
@@ -715,5 +715,6 @@ setMethod("getAlpha", signature = c(x = "SummarizedExperiment"),
     res <- FUN(x = x, mat = mat, index = index, ...)
     res <- as.matrix(res)
     colnames(res) <- paste0(name, colnames(res))
+    rownames(res) <- colnames(x)
     return(res)
 }


### PR DESCRIPTION
Rarefaction in alpha diversity calculation did not work, because the function failed to match samples. The matching is done because rarefaction can drop some samples. It is done based on sample names, however, sample names were not added to results which caused the function to fail.; it returned only NAs because it did not find any matches.