### PR TITLE
Add Tito2024QMP to mia dataset vignettes

### DIFF
--- a/R/mia.R
+++ b/R/mia.R
@@ -44,6 +44,8 @@ NULL
 #'     features and 58 samples}
 #'   \item{\code{\link{Tengeler2020}}: A TreeSummarizedExperiment with 151
 #'     features and 27 samples}
+#'   \item{\code{\link{Tito2024QMP}}: A TreeSummarizedExperiment with 676
+#'     features and 589 samples}
 #' }
 #' 
 #' @name mia-datasets

--- a/man/mia-datasets.Rd
+++ b/man/mia-datasets.Rd
@@ -27,6 +27,8 @@ experiments (microbiota, metabolites and biomarkers)}
 features and 58 samples}
 \item{\code{\link{Tengeler2020}}: A TreeSummarizedExperiment with 151
 features and 27 samples}
+\item{\code{\link{Tito2024QMP}}: A TreeSummarizedExperiment with 676
+features and 589 samples}
 }
 }
 \examples{


### PR DESCRIPTION
Hi! I noticed Tito2024QMP was missing from the mia datasets vignettes so I added it.