### PR TITLE
Add pseudocount as method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.15.33
+Version: 1.15.34
 Authors@R:
     c(person(given = "Tuomas", family = "Borman", role = c("aut", "cre"),
              email = "tuomas.v.borman@utu.fi",

--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -630,6 +630,12 @@ setMethod("transformAssay", signature = c(x = "SingleCellExperiment"),
             stop("The assay contains negative values. ",
                 "'pseudocount' must be specified manually.", call. = FALSE)
         }
+        # If there are only positive, non-zero values, we do not add pseudocount
+        if( all(mat > 0, na.rm = TRUE) ){
+            pseudocount <- 0
+            message("The assay contains already only strictly positive ",
+                    "values. Pseudocount is not added.")
+        }
         # If pseudocount TRUE, set it to half of non-zero minimum value
         # else set it to zero.
         # Get min value

--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -96,6 +96,8 @@
 #' log2 = log2(x)}
 #' where \eqn{x} is a single value of data.
 #'
+#' \item 'pseudocount': Adds only pseudocount.
+#'
 #' }
 #'
 #' @return
@@ -187,12 +189,9 @@ NULL
 #' @rdname transformAssay
 #' @export
 setMethod("transformAssay", signature = c(x = "SummarizedExperiment"),
-    function(x,
+    function(
+        x, method,
         assay.type = "counts", assay_name = NULL,
-        method = c("alr", "chi.square", "clr", "css", "frequency",
-            "hellinger", "log", "log10", "log2", "max", "normalize",
-            "pa", "philr", "range", "rank", "rclr", "relabundance", "rrank",
-            "standardize", "total", "z"),
         MARGIN = "samples",
         name = method,
         pseudocount = FALSE,
@@ -244,8 +243,8 @@ setMethod("transformAssay", signature = c(x = "SingleCellExperiment"),
         method = c(
             "alr", "chi.square", "clr", "css", "frequency",
             "hellinger", "log", "log10", "log2", "max", "normalize",
-            "pa", "philr", "range", "rank", "rclr", "relabundance", "rrank",
-            "standardize", "total", "z"),
+            "pa", "philr", "pseudocount", "range", "rank", "rclr",
+            "relabundance", "rrank", "standardize", "total", "z"),
         MARGIN = "samples",
         name = method,
         pseudocount = FALSE,
@@ -282,6 +281,11 @@ setMethod("transformAssay", signature = c(x = "SingleCellExperiment"),
     # Get the method and abundance table
     method <- match.arg(method)
     assay <- assay(x, assay.type)
+    # If user specified "pseudocount" as method, enable automated pseudocount,
+    # if exact value is not specified
+    if( method == "pseudocount" && .is_a_bool(pseudocount) && !pseudocount ){
+        pseudocount <- TRUE
+    }
     # Apply pseudocount, if it is not 0 or FALSE
     assay <- .apply_pseudocount(assay, pseudocount, ...)
     # Store pseudocount value and set attr equal to NULL. The function above,
@@ -296,6 +300,9 @@ setMethod("transformAssay", signature = c(x = "SingleCellExperiment"),
     } else if( method %in% c("philr") ){
         transformed_table <- .apply_transformation_from_philr(
             assay, method, MARGIN, x = x, ...)
+    } else if ( method %in% c("pseudocount") ){
+        transformed_table <- assay
+        attr(transformed_table, "mia") <- method
     } else {
         transformed_table <- .apply_transformation_from_vegan(
             assay, method, MARGIN, ...)

--- a/man/mia-package.Rd
+++ b/man/mia-package.Rd
@@ -53,6 +53,7 @@ Other contributors:
   \item Katariina Pärnänen [contributor]
   \item Pande Erawijantari [contributor]
   \item Danielle Callan [contributor]
+  \item Jesse Pasanen [contributor]
 }
 
 }

--- a/man/transformAssay.Rd
+++ b/man/transformAssay.Rd
@@ -10,11 +10,9 @@ transformAssay(x, ...)
 
 \S4method{transformAssay}{SummarizedExperiment}(
   x,
+  method,
   assay.type = "counts",
   assay_name = NULL,
-  method = c("alr", "chi.square", "clr", "css", "frequency", "hellinger", "log", "log10",
-    "log2", "max", "normalize", "pa", "philr", "pseudocount", "range", "rank", "rclr",
-    "relabundance", "rrank", "standardize", "total", "z"),
   MARGIN = "samples",
   name = method,
   pseudocount = FALSE,
@@ -53,13 +51,13 @@ If \code{NULL}, the tree is retrieved from \code{x}.
 (Default: \code{NULL}).
 }}
 
+\item{method}{\code{Character scalar}. Specifies the transformation
+method.}
+
 \item{assay.type}{\code{Character scalar}. Specifies the name of assay
 used in calculation. (Default: \code{"counts"})}
 
 \item{assay_name}{Deprecated. Use \code{assay.type} instead.}
-
-\item{method}{\code{Character scalar}. Specifies the transformation
-method.}
 
 \item{MARGIN}{\code{Character scalar}. Determines whether the
 transformation is applied sample (column) or feature (row) wise.

--- a/man/transformAssay.Rd
+++ b/man/transformAssay.Rd
@@ -13,8 +13,8 @@ transformAssay(x, ...)
   assay.type = "counts",
   assay_name = NULL,
   method = c("alr", "chi.square", "clr", "css", "frequency", "hellinger", "log", "log10",
-    "log2", "max", "normalize", "pa", "philr", "range", "rank", "rclr", "relabundance",
-    "rrank", "standardize", "total", "z"),
+    "log2", "max", "normalize", "pa", "philr", "pseudocount", "range", "rank", "rclr",
+    "relabundance", "rrank", "standardize", "total", "z"),
   MARGIN = "samples",
   name = method,
   pseudocount = FALSE,
@@ -129,6 +129,8 @@ the data.
 \deqn{log2 = \log_{2} x}{%
 log2 = log2(x)}
 where \eqn{x} is a single value of data.
+
+\item 'pseudocount': Adds only pseudocount.
 
 }
 }


### PR DESCRIPTION
Sometimes it might be useful to add pseudocount without other transformation (e.g. if additional transformation is applied afterwards). 

This PR adds option to add only pseudocount by using `transformAssay()`.