### PR TITLE
Fix phyloseq converter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.15.35
+Version: 1.15.36
 Authors@R:
     c(person(given = "Tuomas", family = "Borman", role = c("aut", "cre"),
              email = "tuomas.v.borman@utu.fi",

--- a/R/convertFromPhyloseq.R
+++ b/R/convertFromPhyloseq.R
@@ -38,7 +38,7 @@ convertFromPhyloseq <- function(x) {
     }
     #
     # Get the assay
-    counts <- phyloseq::otu_table(x) |> as.matrix() |> unclass()
+    counts <- as(phyloseq::otu_table(x), "matrix")
     # Check the orientation, and transpose if necessary
     if( !phyloseq::taxa_are_rows(x) ){
         counts <- t(counts)


### PR DESCRIPTION
Related to this issue: https://github.com/microbiome/mia/issues/722

In the old version, some phyloseq-specific attributes were still included in the matrix which failed the methods.