### PR TITLE
Add option for adding dimred to melted assay

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.17.0
+Version: 1.17.1
 Authors@R:
     c(person(given = "Tuomas", family = "Borman", role = c("aut", "cre"),
              email = "tuomas.v.borman@utu.fi",

--- a/NEWS
+++ b/NEWS
@@ -173,3 +173,6 @@ Changes in version 1.15.x
 + Improve decontam functions
 + Support precalculated dissimilarity matrix in dbRDA
 + Calculate standard, binary Jaccard index by default
+
+Changes in version 1.17.x
++ Added add.dimred parameter to meltSE() (2025-04-29)

--- a/R/meltAssay.R
+++ b/R/meltAssay.R
@@ -360,7 +360,8 @@ setMethod("meltSE", signature = c(x = "SingleCellExperiment"),
 
 # This function adds dimred to data.frame. The inptu is already validated to
 # work.
-#' @importFrom dplyr rename rownames_to_column
+#' @importFrom dplyr rename
+#' @importFrom tibble rownames_to_column
 .add_dimred_to_melted_data <- function(
         df, x, dimred, col.name = sample_name, sample_name = "SampleID",...){
     # Loop through all dimreds and get the results

--- a/R/meltAssay.R
+++ b/R/meltAssay.R
@@ -12,16 +12,16 @@
 #' \dQuote{SampleID_col} and \dQuote{FeatureID_row}, if row names or column
 #' names are set.
 #'
-#' @inheritParams getDominant 
+#' @inheritParams getDominant
 #' @inheritParams getDissimilarity
-#' 
+#'
 #' @param add.col \code{Logical scalar}. \code{NULL}, or
 #' \code{character vector}. Used to select information from the \code{colData}
 #' to add to the molten assay data. If \code{add.col = NULL} no data will
 #' be added, if \code{add.col = TRUE} all data will be added and if
 #' \code{add.col} is a \code{character} vector, it will be used to subset
 #' to given column names in \code{colData}. (Default: \code{NULL})
-#' 
+#'
 #' @param add_col_data Deprecated. Use \code{add.col} instead.
 #'
 #' @param add.row \code{Logical scalar} or \code{Character vector}. To
@@ -30,17 +30,24 @@
 #' \code{add.row = TRUE} all data will be added and if
 #' \code{add.row} is a \code{character} vector, it will be used to subset
 #' to given column names in \code{rowData}. (Default: \code{NULL})
-#' 
+#'
 #' @param add_row_data Deprecated. Use \code{add.row} instead.
+#'
+#' @param add.dimred \code{Logical scalar} or \code{Character vector}. To
+#' select information from the \code{reducedDim} to add to the molten assay
+#' data. If \code{add.dimred = NULL} no data will be added, if
+#' \code{add.dimred = TRUE} all data will be added and if
+#' \code{add.dimred} is a \code{character} vector, it will be used to subset
+#' to given names in \code{reducedDimNames(x)}. (Default: \code{NULL})
 #'
 #' @param row.name \code{Character scalar}. To use as the output's name
 #' for the feature identifier. (Default: \code{"FeatureID"})
-#' 
+#'
 #' @param feature_name Deprecated. Use \code{row.name} instead.
 #'
 #' @param col.name \code{Character scalar}. To use as the output's name
 #' for the sample identifier. (Default: \code{"SampleID"})
-#' 
+#'
 #' @param sample_name Deprecated. Use \code{col.name} instead.
 #'
 #' @param ... optional arguments:
@@ -76,7 +83,7 @@ NULL
 setMethod("meltSE", signature = c(x = "SummarizedExperiment"),
     function(
         x,
-        assay.type = assay_name, assay_name = "counts", 
+        assay.type = assay_name, assay_name = "counts",
         add.row = add_row_data,
         add_row_data = NULL,
         add.col = add_col_data,
@@ -120,6 +127,20 @@ setMethod("meltSE", signature = c(x = "SummarizedExperiment"),
         molten_assay <- .format_molten_assay(
             molten_assay, x, row.name, col.name, ...)
         return(molten_assay)
+    }
+)
+
+#' @rdname meltSE
+#'
+#' @export
+setMethod("meltSE", signature = c(x = "SingleCellExperiment"),
+    function(x, add.dimred = NULL, ...){
+        add.dimred <- .check_dimred_for_melting(x, add.dimred)
+        df <- callNextMethod(x, ...)
+        if( !is.null(add.dimred) ){
+            df <- .add_dimred_to_melted_data(df, x, add.dimred, ...)
+        }
+        return(df)
     }
 )
 
@@ -215,7 +236,7 @@ setMethod("meltSE", signature = c(x = "SummarizedExperiment"),
     # Get assay, ensure that it is a matrix. Ensure that it has row and colnames
     # from the TreeSE
     mat <- assay(x, assay.type) |>
-        as.matrix() 
+        as.matrix()
     rownames(mat) <- rownames(x)
     colnames(mat) <- colnames(x)
     # Convert it to long format
@@ -303,4 +324,75 @@ setMethod("meltSE", signature = c(x = "SummarizedExperiment"),
         colnames(molten_assay) <- make.names( colnames(molten_assay) )
     }
     return(molten_assay)
+}
+
+# This function validates the add.dimred parameter. The output is standardized.
+.check_dimred_for_melting <- function(x, dimred){
+    # If FALSE, convert to NULL
+    if( length(dimred) == 1L && is.logical(dimred) && !dimred ){
+        dimred <- NULL
+    }
+    # The input can be NULL, i.e., dimred is not added
+    if( !is.null(dimred) ){
+        # Check that there are dimred in the TreeSE
+        dimnames <- reducedDimNames(x)
+        if( length(dimnames) == 0L ){
+            stop("'add.dimred' is specified but reducedDim(x) is empty.",
+                call. = FALSE)
+        }
+        # If the value is TRUE, user want to add all the dimreds
+        if( length(dimred) == 1L && is.logical(dimred) && dimred ){
+            dimred <- dimnames
+        }
+        # If user has specified certain values, check that they exist...
+        dimnames <- setNames(
+            c(dimnames, seq_len(length(dimnames))), c(dimnames, dimnames))
+        if( !all(dimred %in% dimnames) ){
+            stop("All reduced dimensionalities specified by 'dimred' must be ",
+                "present in reducedDim(x).", call. = FALSE)
+        }
+        # And match with the values. This works also for indices, that is why
+        # we do it like this.
+        dimred <- names(dimnames)[ match(dimred, dimnames) ] |> unique()
+    }
+    return(dimred)
+}
+
+# This function adds dimred to data.frame. The inptu is already validated to
+# work.
+#' @importFrom dplyr rename rownames_to_column
+.add_dimred_to_melted_data <- function(
+        df, x, dimred, col.name = sample_name, sample_name = "SampleID",...){
+    # Loop through all dimreds and get the results
+    dim_data <- lapply(dimred, function(dim) reducedDim(x, dim))
+    names(dim_data) <- dimred
+    # Get all the column names and check if there are duplicated names. If there
+    # are, add suffix from dimred
+    column_names <- lapply(dim_data, colnames) |> unlist()
+    if( anyDuplicated(column_names) ){
+        warning("reducedDim() includes duplicated column ",
+                "names that are converted to unique.", call. = FALSE)
+        dim_data <- lapply(dimred, function(dim){
+            temp <- dim_data[[dim]]
+            colnames(temp) <- paste0(colnames(temp), "_", dim)
+            return(temp)
+        })
+    }
+    # Convert to data.frame
+    dim_data <- do.call(cbind, dim_data) |> as.data.frame()
+    # Check if reducedDim includes column named similarly to column including
+    # sample names. If there are, modify the column from reducedDim.
+    if( col.name %in% colnames(dim_data) ){
+        warning("'x' contains a column '", col.name, "' in its ",
+                "reducedDim which will be renamed to '",
+                col.name, "_dimred'", call. = FALSE)
+        dim_data <- dim_data |> rename(
+            !!sym(paste0(col.name, "_dimred")) := !!sym(col.name))
+    }
+    # Add reducedDm data to the table
+    dim_data <- dim_data |>
+        rownames_to_column(col.name)
+    df <- df |>
+        dplyr::left_join(dim_data, by = col.name)
+    return(df)
 }

--- a/R/runCCA.R
+++ b/R/runCCA.R
@@ -339,7 +339,7 @@ setMethod("getRDA", "ANY", function(x, formula, data, ...){
     if( !(is.data.frame(data) || is.matrix(data) || is(data, "DFrame")) ){
         stop("'data' must be data.frame or coarcible to one.", call. = FALSE)
     }
-    if( !((inherits(x, "dist") && attr(dis, "Size") == nrow(data)) ||
+    if( !((inherits(x, "dist") && attr(x, "Size") == nrow(data)) ||
             (!inherits(x, "dist") && ncol(x) == nrow(data)) )  ){
         stop("Number of columns (or length if distance matrix) in 'x' should ",
             "match with number of rows in 'data'.", call. = FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -185,7 +185,7 @@
 
 # Check if metadata has the specified data.
 .check_metadata_present <- function(
-        data.type, x, name = .get_name_in_parent(assay.type)){
+        data.type, x, name = .get_name_in_parent(data.type)){
     if( !.is_non_empty_string(data.type) ){
         stop("'" ,name, "' must be a single non-empty character value.",
             call. = FALSE)

--- a/man/meltSE.Rd
+++ b/man/meltSE.Rd
@@ -3,6 +3,7 @@
 \name{meltSE}
 \alias{meltSE}
 \alias{meltSE,SummarizedExperiment-method}
+\alias{meltSE,SingleCellExperiment-method}
 \title{Converting a
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}}
 object into a long data.frame}
@@ -23,6 +24,8 @@ meltSE(x, ...)
   sample_name = "SampleID",
   ...
 )
+
+\S4method{meltSE}{SingleCellExperiment}(x, add.dimred = NULL, ...)
 }
 \arguments{
 \item{x}{\code{\link[TreeSummarizedExperiment:TreeSummarizedExperiment-class]{TreeSummarizedExperiment}}.}
@@ -67,6 +70,13 @@ for the feature identifier. (Default: \code{"FeatureID"})}
 for the sample identifier. (Default: \code{"SampleID"})}
 
 \item{sample_name}{Deprecated. Use \code{col.name} instead.}
+
+\item{add.dimred}{\code{Logical scalar} or \code{Character vector}. To
+select information from the \code{reducedDim} to add to the molten assay
+data. If \code{add.dimred = NULL} no data will be added, if
+\code{add.dimred = TRUE} all data will be added and if
+\code{add.dimred} is a \code{character} vector, it will be used to subset
+to given names in \code{reducedDimNames(x)}. (Default: \code{NULL})}
 }
 \value{
 A \code{tibble} with the molten data. The assay values are given in a

--- a/tests/testthat/test-0utilites.R
+++ b/tests/testthat/test-0utilites.R
@@ -35,19 +35,27 @@ test_that("meltSE", {
     expect_error(
         mia:::.norm_add_row_data(NA, x, "SampleID", .internal_MARGIN = "col"),
         "'add.col' contains NA")
+    expect_error(mia:::.check_dimred_for_melting(x, "test"))
+    expect_error(mia:::.check_dimred_for_melting(x, TRUE))
+    x <- addMDS(x, method = "euclidean")
+    expect_error(mia:::.check_dimred_for_melting(x, "test"))
+    expect_error(mia:::.check_dimred_for_melting(x, 2))
     #
     # Check that melting works correctly
     se <- GlobalPatterns
+    se <- addMDS(se, method = "euclidean")
     molten_assay <- meltSE(
         se,
         add.row = TRUE,
         add.col = c("X.SampleID", "Primer"),
+        add.dimred = TRUE,
         assay.type = "counts")
     expect_s3_class(molten_assay, c("tbl_df","tbl","data.frame"))
     expect_equal(
         colnames(molten_assay)[c(1:4,11)],
         c("FeatureID","SampleID","counts","Kingdom","X.SampleID"))
     expect_equal(is.numeric(molten_assay$counts), TRUE)
+    expect_true( all(colnames(reducedDim(se)) %in% colnames(molten_assay)) )
     #
     only_assay <- meltSE(se, assay.type = "counts")
     expect_equal(colnames(only_assay)[1:3], c("FeatureID","SampleID","counts"))


### PR DESCRIPTION
Added `add.dimred` to `meltSE()`. Now user can also add ordination results to melted table.

Minor changes in runCCA.R and utils.R are related to non-fatal bugs that are now fixed.