### PR TITLE
Add support for named vector for node labels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.17.3
+Version: 1.17.4
 Authors@R:
     c(person(given = "Tuomas", family = "Borman", role = c("aut", "cre"),
              email = "tuomas.v.borman@utu.fi",

--- a/R/addDissimilarity.R
+++ b/R/addDissimilarity.R
@@ -53,8 +53,11 @@
 #'
 #'   \item \code{node.label} (Unifrac) \code{character vector}. Used only if
 #'   \code{x} is a matrix. Specifies links between rows/columns and tips of
-#'   \code{tree}. The length must equal the number of rows/columns of \code{x}.
-#'   Furthermore, all the node labs must be present in \code{tree}.
+#'   \code{tree}. All the node labs must be present in \code{tree}. For the
+#'   links, you can provide a vector with whose length equals to the number of
+#'   rows/columns in \code{x}. Alternatively, you can provide a named vector
+#'   where \code{names} represent names in abundance table and values their
+#'   corresponding node in tree. 
 #'
 #'   \item \code{chunkSize}: (JSD) \code{Integer scalar}. Defines the size of
 #'   data  send to the individual worker. Only has an effect, if \code{BPPARAM}
@@ -404,6 +407,7 @@ setMethod(
     # Get links and take only nodeLabs
     links <- links_FUN(x)
     links <- links[ , "nodeLab"]
+    names(links) <- rownames(links)
     node.label <- links
 
     # Get assay. By default, dissimilarity between samples is calculated. In

--- a/R/calculateUnifrac.R
+++ b/R/calculateUnifrac.R
@@ -22,12 +22,20 @@
     }
     # node.label should be NULL or character vector specifying links between 
     # rows and tree labels
-    if( !(is.null(node.label) ||
-            (is.character(node.label) && length(node.label) == nrow(x) &&
-            all(node.label[ !is.na(node.label) ] %in% tree$tip.label))) ){
+    node_for_each <- is.character(node.label) &&
+        length(node.label) == nrow(x) &&
+        all(node.label[ !is.na(node.label) ] %in% tree$tip.label)
+    named_vector <- is.character(node.label) && !is.null(names(node.label)) &&
+        all(rownames(x) %in% names(node.label))
+    if( !(is.null(node.label) || node_for_each || named_vector ) ){
         stop(
             "'node.label' must be NULL or character specifying links between ",
             "abundance table and tree labels.", call. = FALSE)
+    }
+    # If the labels were provided as named vector where names represent
+    # original rows and values represent tips.
+    if( named_vector ){
+        node.label <- node.label[ match(rownames(x), names(node.label)) ]
     }
     # check that matrix and tree are compatible
     if( is.null(node.label) && !all(rownames(x) %in% c(tree$tip.label)) ) {

--- a/R/estimateDiversity.R
+++ b/R/estimateDiversity.R
@@ -26,12 +26,20 @@
 
     # Check that node.label is NULL or it specifies links between rownames and
     # node labs
-    if( !( is.null(node.label) ||
-            is.character(node.label) && length(node.label) == nrow(x) ) ){
+    node_for_each <- is.character(node.label) &&
+        length(node.label) == nrow(x) &&
+        all(node.label[ !is.na(node.label) ] %in% tree$tip.label)
+    named_vector <- is.character(node.label) && !is.null(names(node.label)) &&
+        all(rownames(x) %in% names(node.label))
+    if( !(is.null(node.label) || node_for_each || named_vector ) ){
         stop(
-            "'node.label' must be NULL or a vector specifying links between ",
-            "rownames and node labs of 'tree'.",
-            call. = FALSE)
+            "'node.label' must be NULL or character specifying links between ",
+            "abundance table and tree labels.", call. = FALSE)
+    }
+    # If the labels were provided as named vector where names represent
+    # original rows and values represent tips.
+    if( named_vector ){
+        node.label <- node.label[ match(rownames(x), names(node.label)) ]
     }
 
     # Subset rows of the assay to correspond node_labs (if there are any NAs

--- a/R/getMDS.R
+++ b/R/getMDS.R
@@ -128,14 +128,24 @@ setMethod("getMDS", signature = c(x = "TreeSummarizedExperiment"),
 # For TreeSE, we also feed rowTree and node.labels as default
 .get_mds_args_treese <- function(
         x, tree.name = "phylo", tree = NULL, node.label = NULL, ...){
-    # Get tree and corresponding node.labels
-    if( is.null(tree) ){
-        tree <- rowTree(x, tree.name)
+    if( !(.is_a_string(tree.name)) ){
+        stop("'tree.name' must specify a tree from rowTreeNames(x).",
+            call. = FALSE)
     }
-    if( is.null(node.label) ){
-        node.labels <- rowLinks(x)
-        node.labels <- node.labels[
-            node.labels[["whichTree"]] %in% tree.name, "nodeLab"]
+    # Get tree, subset TreeSE, and corresponding node.labels
+    if( is.null(tree) && tree.name %in% rowTreeNames(x) ){
+        tree <- rowTree(x, tree.name)
+        present <- rowLinks(x)[["whichTree"]] %in% tree.name
+        if( !all(present) ){
+            warning(
+                "Not all rows were present in the rowTree specified by ",
+                "'tree.name'. 'x' is subsetted.", call. = FALSE)
+            x <- x[present, ]
+        }
+    }
+    if( is.null(node.label) && tree.name %in% rowTreeNames(x) ){
+        node.label <- rowLinks(x)[["nodeLab"]]
+        names(node.label) <- rownames(x)
     }
     #
     args <- c(.get_mds_args(x, ...), list(tree = tree, node.label = node.label))

--- a/man/getDissimilarity.Rd
+++ b/man/getDissimilarity.Rd
@@ -72,8 +72,11 @@ unweighted-Unifrac dissimilarity is calculated for all pairs of samples.
 
 \item \code{node.label} (Unifrac) \code{character vector}. Used only if
 \code{x} is a matrix. Specifies links between rows/columns and tips of
-\code{tree}. The length must equal the number of rows/columns of \code{x}.
-Furthermore, all the node labs must be present in \code{tree}.
+\code{tree}. All the node labs must be present in \code{tree}. For the
+links, you can provide a vector with whose length equals to the number of
+rows/columns in \code{x}. Alternatively, you can provide a named vector
+where \code{names} represent names in abundance table and values their
+corresponding node in tree.
 
 \item \code{chunkSize}: (JSD) \code{Integer scalar}. Defines the size of
 data  send to the individual worker. Only has an effect, if \code{BPPARAM}

--- a/man/mia-package.Rd
+++ b/man/mia-package.Rd
@@ -21,26 +21,26 @@ summarization.
 
 Authors:
 \itemize{
-  \item Felix G.M. Ernst \email{felix.gm.ernst@outlook.com} (\href{https://orcid.org/0000-0001-5064-0928}{ORCID})
-  \item Sudarshan A. Shetty \email{sudarshanshetty9@gmail.com} (\href{https://orcid.org/0000-0001-7280-9915}{ORCID})
+  \item Felix G.M. Ernst (\href{https://orcid.org/0000-0001-5064-0928}{ORCID})
+  \item Sudarshan A. Shetty (\href{https://orcid.org/0000-0001-7280-9915}{ORCID})
   \item Leo Lahti \email{leo.lahti@iki.fi} (\href{https://orcid.org/0000-0001-5537-637X}{ORCID})
 }
 
 Other contributors:
 \itemize{
   \item Yang Cao [contributor]
-  \item Nathan D. Olson \email{nolson@nist.gov} [contributor]
+  \item Nathan D. Olson [contributor]
   \item Levi Waldron [contributor]
   \item Marcel Ramos [contributor]
   \item Héctor Corrada Bravo [contributor]
   \item Jayaram Kancherla [contributor]
-  \item Domenick Braccia \email{dbraccia@umd.edu} [contributor]
+  \item Domenick Braccia [contributor]
   \item Basil Courbayre [contributor]
   \item Geraldson Muluh [contributor]
   \item Giulio Benedetti [contributor]
-  \item Moritz Emanuel Beber \email{moritz.beber@igdore.org} (\href{https://orcid.org/0000-0003-2406-1978}{ORCID}) [contributor]
+  \item Moritz Emanuel Beber (\href{https://orcid.org/0000-0003-2406-1978}{ORCID}) [contributor]
   \item Chouaib Benchraka [contributor]
-  \item Akewak Jeba \email{akjeba@utu.fi} (\href{https://orcid.org/0009-0007-1347-7552}{ORCID}) [contributor]
+  \item Akewak Jeba (\href{https://orcid.org/0009-0007-1347-7552}{ORCID}) [contributor]
   \item Himmi Lindgren [contributor]
   \item Noah De Gunst [contributor]
   \item Théotime Pralas [contributor]

--- a/tests/testthat/test-5getDissimilarity.R
+++ b/tests/testthat/test-5getDissimilarity.R
@@ -9,10 +9,6 @@ test_that("Dissimilarity calculation", {
   mat <- assay(tse, "counts")
   expect_equal(as.matrix(vegan::vegdist(t(mat), "euclidean")),
                as.matrix(getDissimilarity(tse, method = "euclidean")))
-  tse <- GlobalPatterns
-  # Test if Unifrac dissimilarity works with external tree
-  expect_equal(getDissimilarity(tse, method = "unifrac"),
-               getDissimilarity(tse, tree = rowTree(tse), method = "unifrac"))
   # Test rarefaction
   ntop <- 5
   tse_sub <- tse[head(rev(order(rowSds(assay(tse, "counts")))), ntop), ]
@@ -23,9 +19,24 @@ test_that("Dissimilarity calculation", {
   set.seed(123)
   res1 <- vegan::avgdist(t(mat), distfun = vegdist, dmethod = "euclidean",
                          sample = min(colSums2(mat)), 
-                         iterations = 10, transf = clr)
+                         iterations = 10, transf = clr) |> expect_warning()
   set.seed(123)
   res2 <- getDissimilarity(tse_sub, method = "euclidean", niter = 10, 
-                           transf = clr)
+                           transf = clr) |> expect_warning()
   expect_equal(as.matrix(res1), as.matrix(res2))
+  
+  # Test unifrac with named vector as node labels
+  rownames(tse) <- paste0("taxa", seq_len(nrow(tse)))
+  nodes <- rowLinks(tse)[["nodeLab"]]
+  names(nodes) <- rownames(tse)
+  tse <- tse[1:50, ]
+  #
+  res1 <- getDissimilarity(
+      tse,
+      method = "unifrac",
+      tree = rowTree(tse),
+      node.label = nodes
+  ) |> expect_warning()
+  res2 <- getDissimilarity(tse, method = "unifrac") |> expect_warning()
+  expect_equal(res1, res2)
 })

--- a/tests/testthat/test-addMDS.R
+++ b/tests/testthat/test-addMDS.R
@@ -21,8 +21,8 @@ test_that("Compare addMDS with runMDS", {
     ref <- runMDS(tse, assay.type = "counts", method = "bray", FUN = getDissimilarity, name = "test")
     expect_equal(reducedDim(res, "test"), reducedDim(ref, "test"))
     #
-    res <- getMDS(tse, assay.type = "counts", method = "unifrac", name = "test")
-    ref <- calculateMDS(tse, assay.type = "counts", method = "unifrac", tree = rowTree(tse), FUN = getDissimilarity, name = "test")
+    res <- getMDS(tse, assay.type = "counts", method = "unifrac", name = "test") |> expect_warning()
+    ref <- calculateMDS(tse, assay.type = "counts", method = "unifrac", tree = rowTree(tse), FUN = getDissimilarity, name = "test") |> expect_warning()
     expect_equal(res, ref)
 })
 
@@ -37,4 +37,31 @@ test_that("Check rarefaction", {
     #
     res <- addMDS(tse, assay.type = "counts", method = "bray", niter = 2L, sample = sample, subset.result = FALSE) |> expect_warning()
     expect_true( ncol(res) == ncol(tse) )
+})
+
+test_that("Test named vector as node labels", {
+    data("GlobalPatterns")
+    tse <- GlobalPatterns
+    #
+    named_vector <- rowLinks(tse)[["nodeLab"]]
+    names(named_vector) <- rownames(tse)
+    #
+    tse <- tse[1:100, ]
+    vector <- rowLinks(tse)[["nodeLab"]]
+    #
+    res1 <- getMDS(
+        tse,
+        assay.type = "counts",
+        method = "unifrac",
+        tree = rowTree(tse),
+        node.label = named_vector
+    ) |> expect_warning()
+    res2 <- getMDS(
+        tse,
+        assay.type = "counts",
+        method = "unifrac",
+        tree = rowTree(tse),
+        node.label = named_vector
+    ) |> expect_warning()
+    expect_equal(res1, res2)
 })


### PR DESCRIPTION
Previously, user could only provide linkages between nodes of tree and rows with a vector length of `nrow(x)`. I added support for named vector where names represent `rownames(x)`.

I noticed a problem in `addMDS(x, method = "unifrac")`.

1. It retrieves correct arguments for the MDS calculation, including tree and node labels. These arguments are passed through `scater::calculateMDS()` to `mia::getDissimilarity()`.

2. `scater::calculateMDS()` filters the data (by default, it selects 500 features with highest variance), however, node links are not filtered.

3. This caused an error in `mia::getDissimilarity()` when there were more than 500 node labels.

Now when we use named vector, correct labels can be selected based on filtered abundance table.