### PR TITLE
Generalise agglomerateByModule to non-binary numerical modules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.21.1
+Version: 1.21.2
 Authors@R:
     c(person(given = "Tuomas", family = "Borman", role = c("aut", "cre"),
              email = "tuomas.v.borman@utu.fi",

--- a/NEWS
+++ b/NEWS
@@ -190,3 +190,4 @@ Changes in version 1.19.x
 Changes in version 1.21.x
 + Fixed explained percentages on PCA axes for jointRPCA and hardened
   rank-deficient SVD handling in joint-RPCA (1.21.1, 2026-05-12)
+* Generalise agglomerateByModule to non-binary numerical modules (1.21.2, 2026-05-31)

--- a/R/agglomerate.R
+++ b/R/agglomerate.R
@@ -36,10 +36,10 @@
 #' data of assays the function from \code{scuttle} are used.
 #'
 #' \code{agglomerateByModule} allows to agglomerate features or samples based
-#' on one or multiple variables of logical or numeric binary (0/1) type. It is
-#' particularly useful for agglomerating by taxonomic or functional modules,
-#' each defined by a logical or binary variable in the \code{rowData}, as
-#' features can belong to several modules.
+#' on one or multiple variables of numeric or logical type. It is particularly
+#' useful for agglomerating by taxonomic or functional modules, each defined by
+#' a logical or binary variable in the \code{rowData}, as features can belong to
+#' several modules.
 #'
 #' @return
 #' \code{agglomerateByRank} returns a taxonomically-agglomerated,
@@ -126,7 +126,7 @@
 #' \code{nrow(x)/ncol(x)}. Rows or columns corresponding to the same level will
 #' be merged. If \code{length(levels(group)) == nrow(x)/ncol(x)}, \code{x} will
 #' be returned unchanged. For \code{agglomerateByModule}, \code{group} should
-#' specify one or several names of logical or numeric binary variables from the
+#' specify one or several names of numeric or logical variables from the
 #' \code{rowData(x)/colData(x)} by which to agglomerate rows or columns.
 #'
 #' @param f Deprecated. Use \code{group} instead.

--- a/R/merge.R
+++ b/R/merge.R
@@ -206,24 +206,20 @@
 # and rows features. Each cell specifies the membership of feature to the
 # specific module.
 .check_and_process_modules <- function(modules){
-    # Determine class type and NAs
-    is_logical <- is.logical(modules)
-    is_num <- all(modules == 0 | modules == 1)
-    is_na <- is.na(modules)
     # Check validity of module type
-    if( !is_logical && !is_num ){
-        stop("'groups' variables are not binary.", call. = FALSE)
+    if( !is.logical(modules) && !is.numeric(modules) ){
+        stop("'group' variables must be numeric or logical.", call. = FALSE)
     }
-    # Convert to numeric binary to Boolean adjacency matrix
-    if( is_num ){
-        modules <- modules != 0
-    }
+    # Find NAs
+    is_na <- which(is.na(modules))
     # Replace NAs
-    if( any(is_na) ){
-        warning("NAs were found in 'groups' variables and were removed",
-            "before agglomerating the experiment.", call. = FALSE)
+    if( length(is_na) != 0L ){
+        warning(
+            "NAs in 'group' variables were removed before agglomeration.",
+            call. = FALSE
+        )
         # Zero out NA modules
-        modules[is.na(modules)] <- FALSE
+        modules[is_na] <- 0
     }
     return(modules)
 }

--- a/man/agglomerate-methods.Rd
+++ b/man/agglomerate-methods.Rd
@@ -160,7 +160,7 @@ performed. If vector, the value must be the same length as
 \code{nrow(x)/ncol(x)}. Rows or columns corresponding to the same level will
 be merged. If \code{length(levels(group)) == nrow(x)/ncol(x)}, \code{x} will
 be returned unchanged. For \code{agglomerateByModule}, \code{group} should
-specify one or several names of logical or numeric binary variables from the
+specify one or several names of numeric or logical variables from the
 \code{rowData(x)/colData(x)} by which to agglomerate rows or columns.}
 
 \item{f}{Deprecated. Use \code{group} instead.}
@@ -244,10 +244,10 @@ argument lets the user select how to preserve row or column data. For merge
 data of assays the function from \code{scuttle} are used.
 
 \code{agglomerateByModule} allows to agglomerate features or samples based
-on one or multiple variables of logical or numeric binary (0/1) type. It is
-particularly useful for agglomerating by taxonomic or functional modules,
-each defined by a logical or binary variable in the \code{rowData}, as
-features can belong to several modules.
+on one or multiple variables of numeric or logical type. It is particularly
+useful for agglomerating by taxonomic or functional modules, each defined by
+a logical or binary variable in the \code{rowData}, as features can belong to
+several modules.
 
 \code{agglomerateByRanks} will use by default all available taxonomic ranks,
 but


### PR DESCRIPTION
Hi!

Recently ariadne started supporting numeric matrices describing how much each feature coverage each module (module coverage). So I updated `agglomerateByModule` to also accept this kind of numeric non-binary matrices.