### PR TITLE
Fixed PC explained vars in joint-RPCA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ License: Artistic-2.0 | file LICENSE
 Encoding: UTF-8
 LazyData: false
 Depends:
-    R (>= 4.0),
+    R (>= 4.1.0),
     MultiAssayExperiment,
     SingleCellExperiment,
     SummarizedExperiment,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mia
 Type: Package
-Version: 1.19.8
+Version: 1.19.9
 Authors@R:
     c(person(given = "Tuomas", family = "Borman", role = c("aut", "cre"),
              email = "tuomas.v.borman@utu.fi",

--- a/NEWS
+++ b/NEWS
@@ -186,5 +186,7 @@ Changes in version 1.19.x
 + Use ecodive in UniFrac (1.19.2, 2025-12-09)
 + Added binning transformation (1.19.3, 2026-02-23)
 + Added support for reducedDim in clustering (1.19.5, 2026-03-06)
+
+Changes in version 1.21.x
 + Fixed explained percentages on PCA axes for jointRPCA and hardened
   rank-deficient SVD handling in joint-RPCA (1.21.1, 2026-05-12)

--- a/NEWS
+++ b/NEWS
@@ -186,3 +186,4 @@ Changes in version 1.19.x
 + Use ecodive in UniFrac (1.19.2, 2025-12-09)
 + Added binning transformation (1.19.3, 2026-02-23)
 + Added support for reducedDim in clustering (1.19.5, 2026-03-06)
++ Fixed explained percentages on PCA axes for jointRPCA (1.19.9, 2026-05-12)

--- a/NEWS
+++ b/NEWS
@@ -186,4 +186,5 @@ Changes in version 1.19.x
 + Use ecodive in UniFrac (1.19.2, 2025-12-09)
 + Added binning transformation (1.19.3, 2026-02-23)
 + Added support for reducedDim in clustering (1.19.5, 2026-03-06)
-+ Fixed explained percentages on PCA axes for jointRPCA (1.19.9, 2026-05-12)
++ Fixed explained percentages on PCA axes for jointRPCA and hardened
+  rank-deficient SVD handling in joint-RPCA (1.19.9, 2026-05-12)

--- a/NEWS
+++ b/NEWS
@@ -187,4 +187,4 @@ Changes in version 1.19.x
 + Added binning transformation (1.19.3, 2026-02-23)
 + Added support for reducedDim in clustering (1.19.5, 2026-03-06)
 + Fixed explained percentages on PCA axes for jointRPCA and hardened
-  rank-deficient SVD handling in joint-RPCA (1.19.9, 2026-05-12)
+  rank-deficient SVD handling in joint-RPCA (1.21.1, 2026-05-12)

--- a/R/getRPCA.R
+++ b/R/getRPCA.R
@@ -723,13 +723,26 @@ setMethod("addJointRPCA", signature = c(x = "MultiAssayExperiment"),
         # - Perform SVD on X_U to extract the principal singular values
         # - Normalize by Frobenius norm
         X_U <- Reduce(
-            "+", lapply(sample_loadings, function(u) u %*% t(u))) / n_tables
-        svd_res <- svd(X_U)
-	
-	# R's svd() returns singular values in descending order;
-        # switch to ascending
-	S_shared <- svd_res[["d"]][seq_len(ropt)] |> rev() |> diag()
-        S_shared <- S_shared / norm(S_shared, "F")
+                "+", lapply(sample_loadings, function(u) u %*% t(u))) / n_tables
+            svd_res <- svd(X_U)
+
+            # svd() can return fewer than `ropt` singular values when X_U is
+            # rank-deficient (common here: X_U has rank <= ropt by construction,
+            # and small singular values may be dropped by some LAPACK builds,
+            # notably on Windows). Pad with zeros to keep length == ropt.
+            d <- svd_res[["d"]]
+            if (length(d) < ropt) {
+                d <- c(d, rep(0, ropt - length(d)))
+            }
+            d <- d[seq_len(ropt)]
+
+            # R's svd() returns singular values in descending order;
+            # switch to ascending to match the Gemelli reference
+            # implementation. Use nrow = ropt so that the ropt == 1 case
+            # still yields a 1x1 matrix (diag(scalar) would mis-interpret
+            # the scalar as a dimension).
+            S_shared <- diag(rev(d), nrow = ropt)
+            S_shared <- S_shared / norm(S_shared, "F")
 
         # Align table-specific loadings with updated S_shared for consistent
         # reconstruction
@@ -767,13 +780,20 @@ setMethod("addJointRPCA", signature = c(x = "MultiAssayExperiment"),
     # Run SVD. Our initial first guess are the loadings generated
     # by the traditional SVD.
     svd_res <- svd(observed_stacked)
+
+    # Pad singular values to length `ropt` if svd() returned fewer
+    # (rank-deficient case, BLAS-dependent).
+    d <- svd_res[["d"]]
+    if (length(d) < ropt) {
+        d <- c(d, rep(0, ropt - length(d)))
+    }
+    d <- d[seq_len(ropt)]
+
     U_shared <- svd_res[["u"]][, seq_len(ropt), drop = FALSE]
-    U_shared <- U_shared[
-        , U_shared |> ncol() |> seq_len() |> rev(), drop = FALSE]
-    S_shared <- svd_res[["d"]][ seq_len(ropt) ] |> rev() |> diag()
+    U_shared <- U_shared[, rev(seq_len(ncol(U_shared))), drop = FALSE]
+    S_shared <- diag(rev(d), nrow = ropt)
     V_shared <- svd_res[["v"]][, seq_len(ropt), drop = FALSE]
-    V_shared <- V_shared[
-        , V_shared |> ncol() |> seq_len() |> rev(), drop = FALSE]
+    V_shared <- V_shared[, rev(seq_len(ncol(V_shared))), drop = FALSE]
 
     # The shape and number of non-zero values
     # can set the input parameters for the gradient

--- a/R/getRPCA.R
+++ b/R/getRPCA.R
@@ -725,7 +725,10 @@ setMethod("addJointRPCA", signature = c(x = "MultiAssayExperiment"),
         X_U <- Reduce(
             "+", lapply(sample_loadings, function(u) u %*% t(u))) / n_tables
         svd_res <- svd(X_U)
-        S_shared <- svd_res[["d"]][seq_len(ropt)] |> diag()
+	
+	# R's svd() returns singular values in descending order;
+        # switch to ascending
+	S_shared <- svd_res[["d"]][seq_len(ropt)] |> rev() |> diag()
         S_shared <- S_shared / norm(S_shared, "F")
 
         # Align table-specific loadings with updated S_shared for consistent

--- a/R/getRPCA.R
+++ b/R/getRPCA.R
@@ -114,7 +114,7 @@
 #' The RPCA method is reported in Martino et al. (2020) and the
 #' R/Bioconductor implementation utilizes the robust Aitchison
 #' distance from \code{\link[vegan:decostand]{vegan::decostand}}.
-#' 
+#'
 #' The Joint-RPCA method was adapted from the original
 #' Python-based implementation in biocore/Gemelli by
 #' Bianca Cordazzo Vargas, Liat Shenhav, and Cameron Martino.
@@ -724,25 +724,25 @@ setMethod("addJointRPCA", signature = c(x = "MultiAssayExperiment"),
         # - Normalize by Frobenius norm
         X_U <- Reduce(
                 "+", lapply(sample_loadings, function(u) u %*% t(u))) / n_tables
-            svd_res <- svd(X_U)
+        svd_res <- svd(X_U)
 
-            # svd() can return fewer than `ropt` singular values when X_U is
-            # rank-deficient (common here: X_U has rank <= ropt by construction,
-            # and small singular values may be dropped by some LAPACK builds,
-            # notably on Windows). Pad with zeros to keep length == ropt.
-            d <- svd_res[["d"]]
-            if (length(d) < ropt) {
-                d <- c(d, rep(0, ropt - length(d)))
-            }
-            d <- d[seq_len(ropt)]
+        # svd() can return fewer than `ropt` singular values when X_U is
+        # rank-deficient (common here: X_U has rank <= ropt by construction,
+        # and small singular values may be dropped by some LAPACK builds,
+        # notably on Windows). Pad with zeros to keep length == ropt.
+        d <- svd_res[["d"]]
+        if (length(d) < ropt) {
+            d <- c(d, rep(0, ropt - length(d)))
+        }
+        d <- d[seq_len(ropt)]
 
-            # R's svd() returns singular values in descending order;
-            # switch to ascending to match the Gemelli reference
-            # implementation. Use nrow = ropt so that the ropt == 1 case
-            # still yields a 1x1 matrix (diag(scalar) would mis-interpret
-            # the scalar as a dimension).
-            S_shared <- diag(rev(d), nrow = ropt)
-            S_shared <- S_shared / norm(S_shared, "F")
+        # R's svd() returns singular values in descending order;
+        # switch to ascending to match the Gemelli reference
+        # implementation. Use nrow = ropt so that the ropt == 1 case
+        # still yields a 1x1 matrix (diag(scalar) would mis-interpret
+        # the scalar as a dimension).
+        S_shared <- diag(rev(d), nrow = ropt)
+        S_shared <- S_shared / norm(S_shared, "F")
 
         # Align table-specific loadings with updated S_shared for consistent
         # reconstruction
@@ -790,10 +790,12 @@ setMethod("addJointRPCA", signature = c(x = "MultiAssayExperiment"),
     d <- d[seq_len(ropt)]
 
     U_shared <- svd_res[["u"]][, seq_len(ropt), drop = FALSE]
-    U_shared <- U_shared[, rev(seq_len(ncol(U_shared))), drop = FALSE]
+    U_shared <- U_shared[
+        , U_shared |> ncol() |> seq_len() |> rev(), drop = FALSE]
     S_shared <- diag(rev(d), nrow = ropt)
     V_shared <- svd_res[["v"]][, seq_len(ropt), drop = FALSE]
-    V_shared <- V_shared[, rev(seq_len(ncol(V_shared))), drop = FALSE]
+    V_shared <- V_shared[
+        , V_shared |> ncol() |> seq_len() |> rev(), drop = FALSE]
 
     # The shape and number of non-zero values
     # can set the input parameters for the gradient

--- a/R/getRPCA.R
+++ b/R/getRPCA.R
@@ -723,7 +723,7 @@ setMethod("addJointRPCA", signature = c(x = "MultiAssayExperiment"),
         # - Perform SVD on X_U to extract the principal singular values
         # - Normalize by Frobenius norm
         X_U <- Reduce(
-                "+", lapply(sample_loadings, function(u) u %*% t(u))) / n_tables
+            "+", lapply(sample_loadings, function(u) u %*% t(u))) / n_tables
         svd_res <- svd(X_U)
 
         # svd() can return fewer than `ropt` singular values when X_U is

--- a/R/utils.R
+++ b/R/utils.R
@@ -811,7 +811,7 @@
                 is_index <- is.numeric(altexps[[exp]]) &&
                     all(altexps[[exp]]%%1==0) &&
                     altexps[[exp]]>0 &&
-                    altexps[[exp]]<=length(alExps(mae[[exp]]) )
+                    altexps[[exp]]<=length(altExps(mae[[exp]]) )
                 if( !( is_name || is_index ) ){
                     stop("'", altexps[[exp]], "' does not specify altExp from ",
                         "experiment '", exp, "'.", call. = FALSE)


### PR DESCRIPTION
This fixes the discrepancy in expained variance w.r.t. Gemelli.

The reason was the sorting of svd values (descending vs. ascending); this had been noted elsewhere in the code but was left undone on line 728 of R/getRPCA.R

Now the explained variances match between mia ("percentVar") and Gemelli.
