### PR TITLE
Support UniFrac and pre-calculated dissimilarity in getPERMANOVA (#844)

### DIFF
--- a/R/getPERMANOVA.R
+++ b/R/getPERMANOVA.R
@@ -54,6 +54,9 @@
 #' @param method \code{Character scalar}. A dissimilarity metric used in
 #' PERMANOVA and group dispersion calculation. (Default: \code{"bray"})
 #'
+#' @param dis.name \code{Character scalar}. Specifies the name of dissimilarity
+#' matrix from \code{metadata(x)} used in calculation. (Default: \code{NULL})
+#'
 #' @param test.homogeneity \code{Logical scalar}. Should the homogeneity of
 #' group dispersions be evaluated? (Default: \code{TRUE})
 #'
@@ -105,6 +108,25 @@
 #' # Significance results are similar to PERMANOVA
 #' attr(rda_res, "significance")
 #'
+#' # Perform PERMANOVA with UniFrac directly on TreeSE
+#' tse <- addPERMANOVA(
+#'     tse,
+#'     assay.type = "counts",
+#'     method = "unifrac",
+#'     formula = x ~ SampleType,
+#'     name = "unifrac_permanova",
+#'     permutations = 99
+#' )
+#'
+#' # Run PERMANOVA using a pre-calculated dissimilarity matrix from metadata
+#' tse <- addDissimilarity(tse, method = "unifrac", name = "unifrac_dist")
+#' res_precalc <- getPERMANOVA(
+#'     tse,
+#'     dis.name = "unifrac_dist",
+#'     formula = x ~ SampleType,
+#'     permutations = 99
+#' )
+#'
 #' @seealso
 #' For more details on the actual implementation see
 #' \code{\link[vegan:adonis2]{vegan::adonis2}},
@@ -128,10 +150,9 @@ setMethod("getPERMANOVA", "SingleCellExperiment", function(x,  ...){
 #' @rdname getPERMANOVA
 setMethod("getPERMANOVA", "SummarizedExperiment",
     function(
-        x, assay.type = "counts", formula = NULL, col.var = NULL, ...){
+        x, assay.type = "counts", formula = NULL, col.var = NULL,
+        dis.name = NULL, method = "bray", ...){
         ############################# Input check ##############################
-        # Assay must be present
-        .check_assay_present(assay.type, x)
         # Formula must be either correctly specified or not specified
         if( !(is.null(formula) || is(formula, "formula")) ){
             stop("'formula' must be formula or NULL.", call. = FALSE)
@@ -142,14 +163,45 @@ setMethod("getPERMANOVA", "SummarizedExperiment",
             stop("'col.var' must specify column from colData(x) or be NULL.",
                 call. = FALSE)
         }
+        if( !is.null(formula) && !is.null(col.var) ){
+            stop("Specify either 'formula' or 'col.var'.", call. = FALSE)
+        }
+        if( !.is_a_string(method) ){
+            stop("'method' must be a single character value.", call. = FALSE)
+        }
+        # User can specify either abundance matrix or dissimilarity matrix from
+        # metadata.
+        if( !is.null(dis.name) ){
+            if( !.is_a_string(dis.name) ){
+                stop("'dis.name' must be a single character value.",
+                    call. = FALSE)
+            }
+            .check_metadata_present(dis.name, x)
+            mat <- metadata(x)[[dis.name]]
+            if( is.matrix(mat) ){
+                mat <- as.dist(mat)
+            }
+            if( !inherits(mat, "dist") ){
+                stop("'", dis.name, "' in metadata(x) must be a 'dist' object or ",
+                    "a symmetric distance matrix.", call. = FALSE)
+            }
+        } else{
+            .check_assay_present(assay.type, x)
+            if( method %in% c("unifrac", "overlap", "jsd") ){
+                mat <- getDissimilarity(
+                    x, method = method, assay.type = assay.type, ...)
+            } else{
+                mat <- assay(x, assay.type)
+            }
+        }
         ########################### Input check end ############################
-        # Get abundance table, formula and related sample metadata as DF
-        mat <- assay(x, assay.type)
+        # Get formula and related sample metadata as DF
         temp <- .get_formula_and_covariates(x, formula, col.var)
         formula <- temp[["formula"]]
         covariates <- temp[["variables"]]
-        # Calculate PERMANOVA with matrix method
-        res <- getPERMANOVA(mat, formula = formula, data = covariates, ...)
+        # Calculate PERMANOVA with matrix/dist method
+        res <- getPERMANOVA(
+            mat, formula = formula, data = covariates, method = method, ...)
         return(res)
     }
 )
@@ -158,18 +210,31 @@ setMethod("getPERMANOVA", "SummarizedExperiment",
 #' @rdname getPERMANOVA
 setMethod("getPERMANOVA", "ANY", function(
         x, formula, data, method = "bray", test.homogeneity = TRUE, ...){
-    if( !is.matrix(x) ){
-        stop("'x' must be matrix.", call. = FALSE)
+    is_dist <- inherits(x, "dist")
+    if( !(is.matrix(x) || is_dist) ){
+        stop("'x' must be a matrix or a 'dist' object.", call. = FALSE)
     }
     if( !is(formula, "formula") ){
         stop("'formula' must be formula or NULL.", call. = FALSE)
     }
     if( !(is.data.frame(data) || is.matrix(data) || is(data, "DFrame")) ){
-        stop("'data' must be data.frame or coarcible to one.", call. = FALSE)
+        stop("'data' must be data.frame or coercible to one.", call. = FALSE)
     }
-    if( ncol(x) != nrow(data) ){
-        stop("Number of columns in 'x' should match with number of rows in ",
-            "'data'.", call. = FALSE)
+    n_samples <- if( is_dist ) attr(x, "Size") else ncol(x)
+    if( n_samples != nrow(data) ){
+        if( is_dist ){
+            stop("Number of samples in 'x' should match with number of rows in ",
+                "'data'.", call. = FALSE)
+        } else {
+            stop("Number of columns in 'x' should match with number of rows in ",
+                "'data'.", call. = FALSE)
+        }
+    }
+    # Align rows of data if names match
+    sample_names <- if( is_dist ) labels(x) else colnames(x)
+    if( !is.null(sample_names) && !is.null(rownames(data)) &&
+            setequal(sample_names, rownames(data)) ){
+        data <- data[sample_names, , drop = FALSE]
     }
     if( !.is_a_string(method) ){
         stop("'method' must be a single character value.", call. = FALSE)
@@ -197,7 +262,7 @@ setMethod("addPERMANOVA", "SummarizedExperiment",
     }
     # Calculate permanova
     res <- getPERMANOVA(x, ...)
-    # Addresults to metadata
+    # Add results to metadata
     x <- .add_values_to_metadata(x, name, res)
     return(x)
     }
@@ -206,7 +271,7 @@ setMethod("addPERMANOVA", "SummarizedExperiment",
 ################################ HELP FUNCTIONS ################################
 
 # This function is internal function to perform PERMANOVA from abundance
-# matrix, formula and sample metadata table.
+# matrix or distance matrix, formula and sample metadata table.
 #' @importFrom vegan adonis2
 .calculate_permanova <- function(
         x, formula, data, by = "margin", na.action = na.fail, ...){
@@ -216,8 +281,10 @@ setMethod("addPERMANOVA", "SummarizedExperiment",
     }
     #
     # Get abundance data into correct orientation. Samples must be in rows and
-    # features in columns. Also ensure that the abundance table is matrix.
-    x <- as.matrix(t(x))
+    # features in columns.
+    if( !inherits(x, "dist") ){
+        x <- as.matrix(t(x))
+    }
     # Covariate table must be data.frame
     data <- data.frame(data, check.names = FALSE)
     # Instead of letting na.action pass through, give informative error
@@ -227,7 +294,7 @@ setMethod("addPERMANOVA", "SummarizedExperiment",
             "to remove samples with missing values.", call. = FALSE)
     }
     # This next step ensures that the formula points correctly to abundance
-    # table
+    # table or distance matrix
     formula <- as.character(formula)
     formula[[2]] <- "x"
     formula <- as.formula(

--- a/R/runCCA.R
+++ b/R/runCCA.R
@@ -674,10 +674,15 @@ setMethod("addRDA", "SingleCellExperiment",
             paste0(names(cols)[!cols], collapse = "','"), "'", call. = FALSE)
         variables <- variables[, cols, drop = FALSE]
     }
-    #
     # Calculate dissimilarity matrix
-    mat <- t(mat)
-    diss_mat <- vegdist(mat, method = method, ...)
+    if( inherits(mat, "dist") ){
+        diss_mat <- mat
+    } else if( is.matrix(mat) && isSymmetric(unname(mat)) ){
+        diss_mat <- as.dist(mat)
+    } else {
+        mat <- t(mat)
+        diss_mat <- vegdist(mat, method = method, ...)
+    }
     # For all variables run the analysis
     homogeneity <- lapply(colnames(variables), function(x){
         # Get variable values

--- a/man/getPERMANOVA.Rd
+++ b/man/getPERMANOVA.Rd
@@ -15,7 +15,15 @@ addPERMANOVA(x, ...)
 
 \S4method{getPERMANOVA}{SingleCellExperiment}(x, ...)
 
-\S4method{getPERMANOVA}{SummarizedExperiment}(x, assay.type = "counts", formula = NULL, col.var = NULL, ...)
+\S4method{getPERMANOVA}{SummarizedExperiment}(
+  x,
+  assay.type = "counts",
+  formula = NULL,
+  col.var = NULL,
+  dis.name = NULL,
+  method = "bray",
+  ...
+)
 
 \S4method{getPERMANOVA}{ANY}(x, formula, data, method = "bray", test.homogeneity = TRUE, ...)
 
@@ -67,6 +75,9 @@ including covariates defined by \code{formula}.}
 
 \item{method}{\code{Character scalar}. A dissimilarity metric used in
 PERMANOVA and group dispersion calculation. (Default: \code{"bray"})}
+
+\item{dis.name}{\code{Character scalar}. Specifies the name of dissimilarity
+matrix from \code{metadata(x)} used in calculation. (Default: \code{NULL})}
 
 \item{test.homogeneity}{\code{Logical scalar}. Should the homogeneity of
 group dispersions be evaluated? (Default: \code{TRUE})}
@@ -139,6 +150,25 @@ rda_res <- getRDA(
     formula = x ~ SampleType, permutations = 99)
 # Significance results are similar to PERMANOVA
 attr(rda_res, "significance")
+
+# Perform PERMANOVA with UniFrac directly on TreeSE
+tse <- addPERMANOVA(
+    tse,
+    assay.type = "counts",
+    method = "unifrac",
+    formula = x ~ SampleType,
+    name = "unifrac_permanova",
+    permutations = 99
+)
+
+# Run PERMANOVA using a pre-calculated dissimilarity matrix from metadata
+tse <- addDissimilarity(tse, method = "unifrac", name = "unifrac_dist")
+res_precalc <- getPERMANOVA(
+    tse,
+    dis.name = "unifrac_dist",
+    formula = x ~ SampleType,
+    permutations = 99
+)
 
 }
 \seealso{

--- a/tests/testthat/test-getPERMANOVA.R
+++ b/tests/testthat/test-getPERMANOVA.R
@@ -189,7 +189,7 @@ test_that("getPERMANOVA matches direct calculations", {
         permutations = 99
     )
     homogeneity_direct <- vegan::betadisper(
-        vegdist(t(assay(tse, "relabundance"))),
+        vegan::vegdist(t(assay(tse, "relabundance"))),
         group = tse$SampleType
     )
     
@@ -209,3 +209,98 @@ test_that("getPERMANOVA matches direct calculations", {
     expect_equal(
         res[[2]][[2]][[1]][[1]]$distances, homogeneity_direct$distances)
 })
+
+test_that("getPERMANOVA works with UniFrac and dist object directly", {
+    # Test on-the-fly UniFrac calculation on TreeSummarizedExperiment
+    set.seed(42)
+    res_unifrac <- getPERMANOVA(
+        tse, assay.type = "counts",
+        method = "unifrac",
+        formula = x ~ SampleType,
+        test.homogeneity = TRUE,
+        permutations = 99
+    )
+    expect_type(res_unifrac, "list")
+    expect_s3_class(res_unifrac$permanova, "anova.cca")
+    expect_s3_class(res_unifrac$homogeneity, "data.frame")
+
+    # Test passing a dist object directly
+    d <- getDissimilarity(tse, method = "unifrac")
+    expect_s3_class(d, "dist")
+    setseed_wrap <- set.seed(42)
+    res_dist <- suppressWarnings(getPERMANOVA(
+        d, formula = x ~ SampleType, data = colData(tse),
+        test.homogeneity = TRUE, permutations = 99
+    ))
+    expect_type(res_dist, "list")
+    expect_s3_class(res_dist$permanova, "anova.cca")
+    expect_equal(res_unifrac$permanova$SumOfSqs, res_dist$permanova$SumOfSqs)
+    expect_equal(res_unifrac$permanova$R2, res_dist$permanova$R2)
+    expect_equal(res_unifrac$permanova$F, res_dist$permanova$F)
+})
+
+test_that("getPERMANOVA and addPERMANOVA work with pre-calculated dissimilarity (dis.name)", {
+    # Pre-calculate dissimilarity and store in metadata
+    tse_diss <- addDissimilarity(tse, method = "unifrac", name = "unifrac_dist")
+    expect_true("unifrac_dist" %in% names(metadata(tse_diss)))
+
+    # Run getPERMANOVA using dis.name
+    set.seed(42)
+    res_precalc <- getPERMANOVA(
+        tse_diss, dis.name = "unifrac_dist",
+        formula = x ~ SampleType, permutations = 99
+    )
+    expect_s3_class(res_precalc$permanova, "anova.cca")
+
+    d <- getDissimilarity(tse, method = "unifrac")
+    set.seed(42)
+    res_dist <- suppressWarnings(getPERMANOVA(
+        d, formula = x ~ SampleType, data = colData(tse), permutations = 99
+    ))
+    expect_equal(res_precalc$permanova$SumOfSqs, res_dist$permanova$SumOfSqs)
+    expect_equal(res_precalc$permanova$F, res_dist$permanova$F)
+
+    # Test addPERMANOVA with dis.name
+    tse_meta <- addPERMANOVA(
+        tse_diss, dis.name = "unifrac_dist",
+        formula = x ~ SampleType, name = "perm_precalc", permutations = 99
+    )
+    expect_true("perm_precalc" %in% names(metadata(tse_meta)))
+    expect_s3_class(metadata(tse_meta)[["perm_precalc"]]$permanova, "anova.cca")
+
+    # Test addPERMANOVA with method = unifrac on-the-fly
+    tse_meta2 <- addPERMANOVA(
+        tse, method = "unifrac",
+        formula = x ~ SampleType, name = "perm_unifrac", permutations = 99
+    )
+    expect_true("perm_unifrac" %in% names(metadata(tse_meta2)))
+    expect_s3_class(metadata(tse_meta2)[["perm_unifrac"]]$permanova, "anova.cca")
+})
+
+test_that("getPERMANOVA input validations for dis.name and dist objects", {
+    # Nonexistent dis.name in metadata
+    expect_error(
+        getPERMANOVA(tse, dis.name = "nonexistent", formula = x ~ SampleType),
+        "'dis.name' must be a valid name of metadata"
+    )
+
+    # Invalid dis.name type
+    expect_error(
+        getPERMANOVA(tse, dis.name = 123, formula = x ~ SampleType),
+        "'dis.name' must be a single character value"
+    )
+
+    # Dist object with sample size mismatch
+    d <- getDissimilarity(tse, method = "bray")
+    expect_error(
+        getPERMANOVA(d, formula = x ~ SampleType, data = colData(tse)[1:10, ]),
+        "Number of samples in 'x' should match"
+    )
+
+    # Invalid x (neither matrix nor dist)
+    expect_error(
+        getPERMANOVA(1:10, formula = x ~ SampleType, data = colData(tse)),
+        "'x' must be a matrix or a 'dist' object"
+    )
+})
+


### PR DESCRIPTION
Resolves #844. Extends `getPERMANOVA` and `addPERMANOVA` to support UniFrac and pre-calculated dissimilarity matrices. Tree-aware metrics (`unifrac`, `overlap`, `jsd`) are computed via `mia::getDissimilarity()`, and pre-calculated matrices can be retrieved via `dis.name` from `metadata(x)` or passed directly as `dist` objects. Also updates dispersion testing in `.calculate_homogeneity()` to accept distance objects directly.