### PR TITLE
Add Allen's phylogenetic entropy and Rao's quadratic entropy to addAlpha (#845)

### DIFF
--- a/R/addAlpha.R
+++ b/R/addAlpha.R
@@ -27,13 +27,15 @@
 #'   (Default: \code{min(colSums2(assay(x, assay.type)))})
 #'
 #'   \item \code{tree.name}: \code{Character scalar}. Specifies which rowTree
-#'    will be used. ( Faith's index). (Default: \code{"phylo"})
+#'   will be used. (Phylogenetic indices: Allen, Faith, Rao).
+#'   (Default: \code{"phylo"})
 #'
 #'   \item \code{node.label}: \code{Character vector} or \code{NULL} Specifies
 #'   the links between rows and node labels of phylogeny tree specified
 #'   by \code{tree.name}. If a certain row is not linked with the tree, missing
 #'   instance should be noted as NA. When \code{NULL}, all the rownames should
-#'   be found from the tree. (Faith's index). (Default: \code{NULL})
+#'   be found from the tree. (Phylogenetic indices: Allen, Faith, Rao).
+#'   (Default: \code{NULL})
 #'
 #'   \item \code{only.tips}: (Faith's index). \code{Logical scalar}. Specifies
 #'   whether to remove internal nodes when Faith's index is calculated.
@@ -93,6 +95,10 @@
 #'
 #' \itemize{
 #'
+#' \item 'allen': Allen's phylogenetic entropy generalizes the Shannon index
+#' to phylogenetic trees by weighting branch lengths by descendant relative
+#' abundances (Allen et al. 2009). Using this index requires a tree.
+#'
 #' \item 'coverage': Number of species needed to cover a given fraction of
 #' the ecosystem (50 percent by default). Tune this with the threshold
 #' argument.
@@ -140,6 +146,10 @@
 #' negative skews, we follow Locey & Lennon (2016) and use the log-modulo
 #' transformation that adds a value of one to each measure of skewness to
 #' allow logarithmization.
+#'
+#' \item 'rao': Rao's quadratic entropy calculates the expected phylogenetic
+#' distance between two randomly chosen individuals from the community
+#' (Rao 1982). Using this index requires a tree.
 #'
 #' \item 'shannon': Shannon diversity (entropy).
 #'
@@ -378,6 +388,11 @@
 #' An  index of diversity and its associated diversity measure.
 #' _Oikos_ 70:167--171
 #'
+#' Allen B, Kon M, Bar-Yam Y (2009)
+#' A new phylogenetic diversity measure generalizing the Shannon index and its
+#' application to phyllostomid bats.
+#' _The American Naturalist_ 174(2):236–243.
+#'
 #' Camargo, JA. (1992)
 #' New diversity index for assessing structural alterations in aquatic
 #' communities.
@@ -435,6 +450,10 @@
 #' Pielou, EC. (1966)
 #' The measurement of diversity in different types of
 #' biological collections. _J Theoretical Biology_ 13:131--144.
+#'
+#' Rao CR (1982)
+#' Diversity and dissimilarity coefficients: a unified approach.
+#' _Theoretical Population Biology_ 21(1):24–43.
 #'
 #' Schloss PD (2024) Rarefaction is currently the best approach to control for
 #' uneven sequencing effort in amplicon sequence analyses. _mSphere_
@@ -575,12 +594,13 @@ setMethod("getAlpha", signature = c(x = "SummarizedExperiment"),
     supported <- list()
     # Supported diversity indices
     temp <- c(
-        "coverage", "faith", "fisher", "gini_simpson", "inverse_simpson",
-        "log_modulo_skewness", "shannon")
+        "allen", "coverage", "faith", "fisher", "gini_simpson",
+        "inverse_simpson", "log_modulo_skewness", "rao", "shannon")
     temp <- data.frame(index = temp)
     temp[["measure"]] <- "diversity"
     temp[["index_long"]] <- paste0(temp[["index"]], "_", temp[["measure"]])
-    temp[["non_neg"]] <- c(TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, FALSE)
+    temp[["non_neg"]] <- c(
+        FALSE, TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE)
     supported[["diversity"]] <- temp
     # Supported dominance indices
     temp <- c(
@@ -628,18 +648,30 @@ setMethod("getAlpha", signature = c(x = "SummarizedExperiment"),
             "indices. The following 'index' was not detected: ", not_detected,
             call. = FALSE)
     }
-    # Faith index is available only for TreeSE with rowTree
+    # Tree indices are available only for TreeSE with rowTree or with tree
+    # provided
+    tree_indices <- c("allen", "faith", "rao")
+    missing_tree <- intersect(detected[["index"]], tree_indices)
     tse_with_tree <- (is(x, "TreeSummarizedExperiment") &&
         !is.null(rowTree(x))) || !is.null(tree)
-    if( "faith" %in% detected[["index"]] && !tse_with_tree ){
-        # Drop faith index from indices being calculated
-        detected <- detected[!detected[["index"]] %in% c("faith"), ]
+    if( length(missing_tree) > 0 && !tse_with_tree ){
+        # Drop tree indices from indices being calculated
+        detected <- detected[!detected[["index"]] %in% missing_tree, ]
         # If there are still other indices being calculated, give warning.
-        # Otherwise, give error if faith was the only index that user wants to
-        # calculate.
+        # Otherwise, give error if tree index was the only index that user
+        # wants to calculate.
         FUN <- if( nrow(detected) == 0 ) stop else warning
-        FUN("'faith' index can be calculated only for TreeSE with rowTree(x) ",
-            "populated or with 'tree' provided separately.", call. = FALSE)
+        msg <- if( length(missing_tree) == 1 ){
+            paste0(
+                "'", missing_tree, "' index can be calculated only for TreeSE ",
+                "with rowTree(x) populated or with 'tree' provided separately.")
+        } else {
+            paste0(
+                "The following indices can be calculated only for TreeSE with ",
+                "rowTree(x) populated or with 'tree' provided separately: '",
+                paste0(missing_tree, collapse = "', '"), "'")
+        }
+        FUN(msg, call. = FALSE)
     }
     # Check for unsupported values (negative values)
     if( any(assay(x, assay.type) < 0 & !is.na(assay(x, assay.type))) ){
@@ -705,6 +737,7 @@ setMethod("getAlpha", signature = c(x = "SummarizedExperiment"),
     mat <- assay(x, assay.type)
     # Get correct function based on index
     FUN <- switch(index,
+        allen = .estimate_allen,
         shannon = .calc_shannon,
         gini_simpson = .calc_gini_simpson,
         inverse_simpson = .calc_inverse_simpson,
@@ -712,6 +745,7 @@ setMethod("getAlpha", signature = c(x = "SummarizedExperiment"),
         fisher = .calc_fisher,
         faith = .estimate_faith,
         log_modulo_skewness = .calc_log_modulo_skewness,
+        rao = .estimate_rao,
         #
         simpson_lambda = .simpson_lambda,
         core_abundance = .calc_core_dominance,

--- a/R/estimateDiversity.R
+++ b/R/estimateDiversity.R
@@ -1,7 +1,7 @@
-
-.estimate_faith <- function(
+# Helper function to extract tree and align matrix with tree nodes
+.get_tree_and_linked_mat <- function(
         x, mat, tree = NULL, tree.name = "phylo", node.label = node_lab,
-        node_lab = NULL, ...){
+        node_lab = NULL, index_name = "phylogenetic", ...){
     # Input check
     # If tree is NULL, then we must have TreeSE object that has rowTree
     if( is.null(tree) &&
@@ -20,7 +20,7 @@
     if( is.null(tree) || is.null(tree$edge.length) ){
         stop(
             "'tree' is NULL or it does not have any branches. ",
-            "The Faith's alpha diversity index is not possible to ",
+            "The ", index_name, " alpha diversity index is not possible to ",
             "calculate.", call. = FALSE)
     }
 
@@ -48,7 +48,7 @@
         warning(
             "The tree named does not include all the ",
             "rows. 'x' is subsetted.", call. = FALSE)
-        mat <- mat[ !is.na(node.label), ]
+        mat <- mat[ !is.na(node.label), , drop = FALSE]
         node.label <- node.label[ !is.na(node.label) ]
     }
     # If there are node labels (any TreeSE should have because they are rowLinks
@@ -58,14 +58,38 @@
         rownames(mat) <- node.label
     }
 
-    # To calculate faith, the assay must have rownames. TreeSE has always
-    # rownames at this point, but if the object is SE, it might be that it is
-    # missing rownames.
+    # To calculate tree diversity, the assay must have rownames. TreeSE has
+    # always rownames at this point, but if the object is SE, it might be that
+    # it is missing rownames.
     if( is.null(rownames(mat)) ){
         stop("'x' must have rownames.", call. = FALSE)
     }
-    # Calculates Faith index
-    res <- .calc_faith(mat, tree, ...)
+    return(list(mat = mat, tree = tree))
+}
+
+.estimate_faith <- function(x, mat, ...){
+    temp <- .get_tree_and_linked_mat(x, mat, index_name = "Faith's", ...)
+    res <- .calc_faith(temp$mat, temp$tree, ...)
+    return(res)
+}
+
+.estimate_allen <- function(x, mat, ...){
+    temp <- .get_tree_and_linked_mat(x, mat, index_name = "Allen's", ...)
+    args <- list(...)
+    args <- args[ !names(args) %in% c("index") ]
+    res <- do.call(
+        .calc_tree_diversity,
+        c(list(mat = temp$mat, tree = temp$tree, index = "allen"), args))
+    return(res)
+}
+
+.estimate_rao <- function(x, mat, ...){
+    temp <- .get_tree_and_linked_mat(x, mat, index_name = "Rao's", ...)
+    args <- list(...)
+    args <- args[ !names(args) %in% c("index") ]
+    res <- do.call(
+        .calc_tree_diversity,
+        c(list(mat = temp$mat, tree = temp$tree, index = "rao"), args))
     return(res)
 }
 
@@ -150,6 +174,65 @@ NULL
     return(.faith_cpp(mat, tree))
 }
 
+.calc_tree_diversity <- function(mat, tree, index = c("allen", "rao"), ...){
+    index <- match.arg(index)
+    # Ensure NAs are 0
+    mat[ is.na(mat) ] <- 0
+    # Relative abundances per sample
+    rel <- .calc_rel_abund(mat)
+    # Ensure matrix format
+    if( is.vector(rel) ){
+        rel <- matrix(
+            rel, ncol = 1, dimnames = list(rownames(mat), colnames(mat)))
+    }
+    # In case any sample has sum 0, rel can have NaNs
+    rel[ is.nan(rel) ] <- 0
+
+    # Reorder tree in postorder for single-pass bottom-up accumulation
+    tree <- reorder.phylo(tree, "postorder")
+    n_tips <- length(tree$tip.label)
+    n_nodes <- tree$Nnode
+    n_samples <- ncol(rel)
+
+    node_abund <- matrix(0, nrow = n_tips + n_nodes, ncol = n_samples)
+    m <- match(tree$tip.label, rownames(rel))
+    valid_tips <- !is.na(m)
+    node_abund[which(valid_tips), ] <- rel[m[valid_tips], , drop = FALSE]
+
+    edge <- tree$edge
+    edge_len <- tree$edge.length
+
+    if( any(is.na(edge_len)) ){
+        stop("'tree$edge.length' contains NA values.", call. = FALSE)
+    }
+
+    res <- numeric(n_samples)
+
+    for( i in seq_len(nrow(edge)) ){
+        child <- edge[i, 2]
+        parent <- edge[i, 1]
+        a_i <- node_abund[child, ]
+        L_i <- edge_len[i]
+
+        # Accumulate descendant abundance to parent node
+        node_abund[parent, ] <- node_abund[parent, ] + a_i
+
+        # Calculate contribution
+        pos <- a_i > 0
+        if( any(pos) ){
+            if( index == "allen" ){
+                # Allen: - L_i * a_i * log(a_i)
+                res[pos] <- res[pos] - L_i * a_i[pos] * log(a_i[pos])
+            } else if( index == "rao" ){
+                # Rao: 2 * L_i * a_i * (1 - a_i)
+                res[pos] <- res[pos] + 2 * L_i * a_i[pos] * (1 - a_i[pos])
+            }
+        }
+    }
+    names(res) <- colnames(mat)
+    return(res)
+}
+
 .calc_log_modulo_skewness <- function(mat, quantile = 0.5,
     nclasses = num_of_classes, num_of_classes = 50, ...){
     # quantile must be a numeric value between 0-1
@@ -202,13 +285,15 @@ NULL
 #' @importFrom SummarizedExperiment assay assays
 .get_diversity_values <- function(index, x, mat, ...){
     FUN <- switch(index,
+        allen = .estimate_allen,
         shannon = .calc_shannon,
         gini_simpson = .calc_gini_simpson,
         inverse_simpson = .calc_inverse_simpson,
         coverage = .calc_coverage,
         fisher = .calc_fisher,
         faith = .estimate_faith,
-        log_modulo_skewness = .calc_log_modulo_skewness
+        log_modulo_skewness = .calc_log_modulo_skewness,
+        rao = .estimate_rao
         )
     res <- FUN(x = x, mat = mat, ...)
     res <- unname(res)

--- a/R/estimateDiversity.R
+++ b/R/estimateDiversity.R
@@ -69,14 +69,20 @@
 
 .estimate_faith <- function(x, mat, ...){
     temp <- .get_tree_and_linked_mat(x, mat, index_name = "Faith's", ...)
-    res <- .calc_faith(temp$mat, temp$tree, ...)
+    args <- list(...)
+    args <- args[ !names(args) %in% c(
+        "tree", "tree.name", "node.label", "node_lab", "index_name", "index") ]
+    res <- do.call(
+        .calc_faith,
+        c(list(mat = temp$mat, tree = temp$tree), args))
     return(res)
 }
 
 .estimate_allen <- function(x, mat, ...){
     temp <- .get_tree_and_linked_mat(x, mat, index_name = "Allen's", ...)
     args <- list(...)
-    args <- args[ !names(args) %in% c("index") ]
+    args <- args[ !names(args) %in% c(
+        "tree", "tree.name", "node.label", "node_lab", "index_name", "index") ]
     res <- do.call(
         .calc_tree_diversity,
         c(list(mat = temp$mat, tree = temp$tree, index = "allen"), args))
@@ -86,7 +92,8 @@
 .estimate_rao <- function(x, mat, ...){
     temp <- .get_tree_and_linked_mat(x, mat, index_name = "Rao's", ...)
     args <- list(...)
-    args <- args[ !names(args) %in% c("index") ]
+    args <- args[ !names(args) %in% c(
+        "tree", "tree.name", "node.label", "node_lab", "index_name", "index") ]
     res <- do.call(
         .calc_tree_diversity,
         c(list(mat = temp$mat, tree = temp$tree, index = "rao"), args))

--- a/man/addAlpha.Rd
+++ b/man/addAlpha.Rd
@@ -33,13 +33,15 @@ depth i.e. the number of counts drawn from each sample.
 (Default: \code{min(colSums2(assay(x, assay.type)))})
 
 \item \code{tree.name}: \code{Character scalar}. Specifies which rowTree
-will be used. ( Faith's index). (Default: \code{"phylo"})
+will be used. (Phylogenetic indices: Allen, Faith, Rao).
+(Default: \code{"phylo"})
 
 \item \code{node.label}: \code{Character vector} or \code{NULL} Specifies
 the links between rows and node labels of phylogeny tree specified
 by \code{tree.name}. If a certain row is not linked with the tree, missing
 instance should be noted as NA. When \code{NULL}, all the rownames should
-be found from the tree. (Faith's index). (Default: \code{NULL})
+be found from the tree. (Phylogenetic indices: Allen, Faith, Rao).
+(Default: \code{NULL})
 
 \item \code{only.tips}: (Faith's index). \code{Logical scalar}. Specifies
 whether to remove internal nodes when Faith's index is calculated.
@@ -118,6 +120,10 @@ The following diversity indices are available:
 
 \itemize{
 
+\item 'allen': Allen's phylogenetic entropy generalizes the Shannon index
+to phylogenetic trees by weighting branch lengths by descendant relative
+abundances (Allen et al. 2009). Using this index requires a tree.
+
 \item 'coverage': Number of species needed to cover a given fraction of
 the ecosystem (50 percent by default). Tune this with the threshold
 argument.
@@ -165,6 +171,10 @@ These are typically right-skewed; to avoid taking log of occasional
 negative skews, we follow Locey & Lennon (2016) and use the log-modulo
 transformation that adds a value of one to each measure of skewness to
 allow logarithmization.
+
+\item 'rao': Rao's quadratic entropy calculates the expected phylogenetic
+distance between two randomly chosen individuals from the community
+(Rao 1982). Using this index requires a tree.
 
 \item 'shannon': Shannon diversity (entropy).
 
@@ -429,6 +439,11 @@ Bulla L. (1994)
 An  index of diversity and its associated diversity measure.
 \emph{Oikos} 70:167--171
 
+Allen B, Kon M, Bar-Yam Y (2009)
+A new phylogenetic diversity measure generalizing the Shannon index and its
+application to phyllostomid bats.
+\emph{The American Naturalist} 174(2):236–243.
+
 Camargo, JA. (1992)
 New diversity index for assessing structural alterations in aquatic
 communities.
@@ -486,6 +501,10 @@ Species richness estimators: how many species can dance on the head of a pin?
 Pielou, EC. (1966)
 The measurement of diversity in different types of
 biological collections. \emph{J Theoretical Biology} 13:131--144.
+
+Rao CR (1982)
+Diversity and dissimilarity coefficients: a unified approach.
+\emph{Theoretical Population Biology} 21(1):24–43.
 
 Schloss PD (2024) Rarefaction is currently the best approach to control for
 uneven sequencing effort in amplicon sequence analyses. \emph{mSphere}

--- a/tests/testthat/test-addAlpha.R
+++ b/tests/testthat/test-addAlpha.R
@@ -241,4 +241,11 @@ test_that("Estimate Phylogenetic Alpha Diversity Indices (allen, rao)", {
         all(c("allen_rare", "rao_rare") %in% colnames(colData(tse_rare))))
     expect_true(is.numeric(tse_rare$allen_rare))
     expect_true(is.numeric(tse_rare$rao_rare))
+
+    # Explicit tree argument works for phylogenetic indices
+    tse_exp_tree <- addAlpha(
+        esophagus, assay.type = "counts",
+        index = c("faith", "allen", "rao"), tree = rowTree(esophagus))
+    expect_true(all(
+        c("faith", "allen", "rao") %in% colnames(colData(tse_exp_tree))))
 })

--- a/tests/testthat/test-addAlpha.R
+++ b/tests/testthat/test-addAlpha.R
@@ -159,3 +159,86 @@ test_that("Estimate Alpha Diversity Indices with Rarefaction", {
     res2 <- colData(tse)
     expect_equal(res, res2)
 })
+
+test_that("Estimate Phylogenetic Alpha Diversity Indices (allen, rao)", {
+    data(GlobalPatterns, package = "mia")
+    tse <- GlobalPatterns
+
+    # Test getAlpha and addAlpha with allen and rao
+    tse <- addAlpha(tse, assay.type = "counts", index = c("allen", "rao"))
+    expect_true("allen" %in% colnames(colData(tse)))
+    expect_true("rao" %in% colnames(colData(tse)))
+    expect_true(is.numeric(tse$allen))
+    expect_true(is.numeric(tse$rao))
+    expect_true(all(tse$allen >= 0, na.rm = TRUE))
+    expect_true(all(tse$rao >= 0, na.rm = TRUE))
+
+    # Test full index names / aliases
+    tse_alias <- addAlpha(
+        GlobalPatterns, assay.type = "counts",
+        index = c("allen_diversity", "rao_diversity"))
+    expect_equal(tse$allen, tse_alias$allen_diversity)
+    expect_equal(tse$rao, tse_alias$rao_diversity)
+
+    # Test getAlpha returns same values as addAlpha
+    res_get <- getAlpha(
+        GlobalPatterns, assay.type = "counts", index = c("allen", "rao"))
+    expect_equal(res_get$allen, tse$allen)
+    expect_equal(res_get$rao, tse$rao)
+
+    # Test custom names
+    tse_custom <- addAlpha(
+        tse, assay.type = "counts",
+        index = c("allen", "rao"), name = c("my_allen", "my_rao"))
+    expect_true(all(c("my_allen", "my_rao") %in% colnames(colData(tse_custom))))
+    expect_equal(tse$allen, tse_custom$my_allen)
+    expect_equal(tse$rao, tse_custom$my_rao)
+
+    # Mathematical equivalence tests on star trees:
+    # 1. Star tree with branch lengths = 1: Allen diversity equals Shannon
+    # diversity
+    set.seed(42)
+    mat <- matrix(rpois(20, lambda = 50), nrow = 4, ncol = 5)
+    rownames(mat) <- paste0("t", 1:4)
+    colnames(mat) <- paste0("s", 1:5)
+    tree1 <- ape::stree(4, type = "star")
+    tree1$tip.label <- rownames(mat)
+    tree1$edge.length <- rep(1, 4)
+    se1 <- TreeSummarizedExperiment(
+        assays = list(counts = mat), rowTree = tree1)
+
+    allen_vals <- getAlpha(se1, index = "allen")[[1]]
+    shannon_vals <- getAlpha(se1, index = "shannon")[[1]]
+    expect_equal(allen_vals, shannon_vals)
+
+    # 2. Star tree with branch lengths = 0.5 (cophenetic distance between any
+    # two distinct tips = 1): Rao's quadratic entropy equals Gini-Simpson index
+    tree_half <- tree1
+    tree_half$edge.length <- rep(0.5, 4)
+    se_half <- TreeSummarizedExperiment(
+        assays = list(counts = mat), rowTree = tree_half)
+
+    rao_vals <- getAlpha(se_half, index = "rao")[[1]]
+    simpson_vals <- getAlpha(se_half, index = "gini_simpson")[[1]]
+    expect_equal(rao_vals, simpson_vals)
+
+    # Error handling: Missing rowTree
+    se_no_tree <- SummarizedExperiment(assays = list(counts = mat))
+    expect_error(getAlpha(se_no_tree, index = "allen"), "rowTree")
+    expect_error(getAlpha(se_no_tree, index = "rao"), "rowTree")
+    expect_error(addAlpha(se_no_tree, index = "allen"), "rowTree")
+    expect_error(addAlpha(se_no_tree, index = "rao"), "rowTree")
+
+    # Rarefaction works with phylogenetic indices
+    data(esophagus, package = "mia")
+    tse_rare <- addAlpha(
+        esophagus, assay.type = "counts",
+        index = c("allen", "rao"),
+        sample = min(colSums(assay(esophagus, "counts"))),
+        niter = 5,
+        name = c("allen_rare", "rao_rare"))
+    expect_true(
+        all(c("allen_rare", "rao_rare") %in% colnames(colData(tse_rare))))
+    expect_true(is.numeric(tse_rare$allen_rare))
+    expect_true(is.numeric(tse_rare$rao_rare))
+})


### PR DESCRIPTION
Closes #845. Adds abundance-weighted phylogenetic alpha diversity indices—Allen's phylogenetic entropy (`allen`) and Rao's quadratic entropy (`rao`)—to `getAlpha()` and `addAlpha()` via single-pass postorder tree traversal in `.calc_tree_diversity()`, unifying tree extraction with Faith's index and adding unit tests for aliases, missing trees, and star-tree equivalence to Shannon and Gini-Simpson.