### PR TITLE
Align method = 'log' with log2 and log10 in transformAssay (#813)

### DIFF
--- a/R/transformCounts.R
+++ b/R/transformCounts.R
@@ -76,9 +76,9 @@
 #'
 #' \itemize{
 #'
-#' \item 'alr', 'chi.square', 'clr', 'frequency', 'hellinger', 'log',
-#' 'normalize', 'pa', 'rank', 'rclr', 'relabundance', 'rrank', 'standardize',
-#' 'total': please refer to
+#' \item 'alr', 'chi.square', 'clr', 'frequency', 'hellinger',
+#' 'log.decostand', 'normalize', 'pa', 'rank', 'rclr', 'relabundance',
+#' 'rrank', 'standardize', 'total': please refer to
 #' \code{\link[vegan:decostand]{decostand}} for details.
 #'
 #' \item 'philr': please refer to \code{\link[philr:philr]{philr}} for details.
@@ -90,6 +90,12 @@
 #' might be \code{0.5}. The method is inspired by the CSS methods in
 #' \code{\link[https://www.bioconductor.org/packages/metagenomeSeq/]{metagenomeSeq}}
 #' package.
+#'
+#' \item 'log': Logarithmic transformation (natural log, base \eqn{e}) can be
+#' used for reducing the skewness of the data.
+#' \deqn{log = \log_{e} x}{%
+#' log = log(x)}
+#' where \eqn{x} is a single value of data.
 #'
 #' \item 'log10': log10 transformation can be used for reducing the skewness
 #' of the data.
@@ -286,9 +292,9 @@ setMethod("transformAssay", signature = c(x = "SingleCellExperiment"),
             "alr", "binning", "chi.square", "clr", "css", "cutoff",
             "difference", "-",
             "division", "/", "frequency", "hellinger", "invnorm", "log",
-            "log10", "log2", "max", "normalize", "pa", "philr", "pseudocount",
-            "range", "rank", "rclr", "relabundance", "rrank", "standardize",
-            "total", "z"),
+            "log.decostand", "log_decostand", "log10", "log2", "max",
+            "normalize", "pa", "philr", "pseudocount", "range", "rank", "rclr",
+            "relabundance", "rrank", "standardize", "total", "z"),
         MARGIN = "samples",
         name = method,
         pseudocount = FALSE,
@@ -340,7 +346,7 @@ setMethod("transformAssay", signature = c(x = "SingleCellExperiment"),
     attr(assay, "pseudocount") <- NULL
     # Calls help function that does the transformation
     # Help function is different for mia and vegan transformations
-    if( method %in% c("binning", "log10", "log2", "css", "difference",
+    if( method %in% c("binning", "log", "log10", "log2", "css", "difference",
             "division", "invnorm") ){
         transformed_table <- .apply_transformation(
             assay, method, MARGIN, ...)
@@ -376,6 +382,7 @@ setMethod("transformAssay", signature = c(x = "SingleCellExperiment"),
     FUN <- switch(
         method,
         binning = .apply_binning,
+        log = .calc_log,
         log10 = .calc_log,
         log2 = .calc_log,
         css = .calc_css,
@@ -419,6 +426,8 @@ setMethod("transformAssay", signature = c(x = "SingleCellExperiment"),
     }
     # Adjust method if mia-specific alias was used
     method <- ifelse(method == "relabundance", "total", method)
+    method <- ifelse(
+        method %in% c("log.decostand", "log_decostand"), "log", method)
     if (method == "z") {
         .Deprecated(old="z", new="standardize")
     }
@@ -463,11 +472,13 @@ setMethod("transformAssay", signature = c(x = "SingleCellExperiment"),
             " transformation is being applied without pseudocount.",
             "`pseudocount` must be set to TRUE.", call. = FALSE)
     }
-    # Calculate log2 or log10 abundances
-    if(method == "log2"){
+    # Calculate log, log2, or log10 abundances
+    if( method == "log2" ){
         mat <- log2(mat)
-    } else{
+    } else if( method == "log10" ){
         mat <- log10(mat)
+    } else if( method == "log" ){
+        mat <- log(mat)
     }
     # Add parameter to attributes
     attr(mat, "parameters") <- list()

--- a/man/transformAssay.Rd
+++ b/man/transformAssay.Rd
@@ -108,9 +108,9 @@ The available transformation methods include:
 
 \itemize{
 
-\item 'alr', 'chi.square', 'clr', 'frequency', 'hellinger', 'log',
-'normalize', 'pa', 'rank', 'rclr', 'relabundance', 'rrank', 'standardize',
-'total': please refer to
+\item 'alr', 'chi.square', 'clr', 'frequency', 'hellinger',
+'log.decostand', 'normalize', 'pa', 'rank', 'rclr', 'relabundance',
+'rrank', 'standardize', 'total': please refer to
 \code{\link[vegan:decostand]{decostand}} for details.
 
 \item 'philr': please refer to \code{\link[philr:philr]{philr}} for details.
@@ -122,6 +122,12 @@ counts. If you want to specify the percentile value, good default value
 might be \code{0.5}. The method is inspired by the CSS methods in
 \code{\link[https://www.bioconductor.org/packages/metagenomeSeq/]{metagenomeSeq}}
 package.
+
+\item 'log': Logarithmic transformation (natural log, base \eqn{e}) can be
+used for reducing the skewness of the data.
+\deqn{log = \log_{e} x}{%
+log = log(x)}
+where \eqn{x} is a single value of data.
 
 \item 'log10': log10 transformation can be used for reducing the skewness
 of the data.

--- a/tests/testthat/test-5transformCounts.R
+++ b/tests/testthat/test-5transformCounts.R
@@ -11,8 +11,12 @@ test_that("transformAssay", {
         expect_error(mia::transformAssay(tse, method="relabundance", name = c("123", "456")))
 
         # Pseudocount is a string. Should be an error.
-        expect_error(mia::transformAssay(tse, method="log10", pseudocount = "pseudocount"))
-        expect_error(mia::transformAssay(tse, method="log2", pseudocount = FALSE))
+        expect_error(
+            mia::transformAssay(tse, method="log10", pseudocount="pseudocount"))
+        expect_error(
+            mia::transformAssay(tse, method="log2", pseudocount = FALSE))
+        expect_error(
+            mia::transformAssay(tse, method="log", pseudocount = FALSE))
 
         # Counts table should not be changed
         expect_equal(assays(mia::transformAssay(tse, method = "pa"))$counts, assays(tse)$counts,
@@ -69,6 +73,57 @@ test_that("transformAssay", {
                      apply(as.matrix(assay(tse, "counts")), 2, FUN=function(x){
                          log2(x+5)
                      }), check.attributes = FALSE)
+
+        ########################### LOG (NATURAL LOG) ##########################
+        # Calculates natural log transformation with pseudocount.
+        tmp <- mia::transformAssay(tse, method = "log", pseudocount = 1)
+        ass <- assays(tmp)$log
+        expect_equal(
+            as.matrix(ass),
+            apply(as.matrix(assay(tse, "counts")), 2, function(x) log(x + 1)),
+            check.attributes = FALSE)
+
+        # Tests transformAssay(MARGIN = "features"), calculates log with
+        # pseudocount. Should be equal.
+        tmp <- mia::transformAssay(
+            tse, MARGIN = "features", method = "log", pseudocount = 1)
+        ass <- assays(tmp)$log
+        expect_equal(
+            as.matrix(ass),
+            t(apply(
+                as.matrix(t(assay(tse, "counts"))), 2,
+                function(x) log(x + 1))),
+            check.attributes = FALSE)
+
+        # Calculates log, log2, and log10 consistency on counts + 1
+        cnts <- as.matrix(assay(tse, "counts"))
+        tmp_log <- mia::transformAssay(tse, method = "log", pseudocount = 1)
+        tmp_log2 <- mia::transformAssay(tse, method = "log2", pseudocount = 1)
+        tmp_log10 <- mia::transformAssay(tse, method = "log10", pseudocount = 1)
+        expect_equal(
+            as.matrix(assays(tmp_log)$log), log(cnts + 1),
+            check.attributes = FALSE)
+        expect_equal(
+            as.matrix(assays(tmp_log2)$log2), log2(cnts + 1),
+            check.attributes = FALSE)
+        expect_equal(
+            as.matrix(assays(tmp_log10)$log10), log10(cnts + 1),
+            check.attributes = FALSE)
+
+        ########################### LOG.DECOSTAND ##############################
+        # Calculates Anderson's log transformation from vegan::decostand
+        tmp_dec <- mia::transformAssay(tse, method = "log.decostand")
+        ass_dec <- assays(tmp_dec)$log.decostand
+        expect_equal(
+            as.matrix(ass_dec),
+            as.matrix(vegan::decostand(cnts, method = "log", MARGIN = 2)),
+            check.attributes = FALSE)
+
+        # Alias log_decostand gives identical result
+        tmp_dec2 <- mia::transformAssay(tse, method = "log_decostand")
+        expect_equal(
+            assays(tmp_dec)$log.decostand, assays(tmp_dec2)$log_decostand,
+            check.attributes = FALSE)
 
         ############################ CSS ######################################
         # Define counts matrix for the css and css_fast testing


### PR DESCRIPTION
Closes #813. Aligns `transformAssay(..., method = "log")` to compute the natural logarithm (base e) natively with pseudocount support, ensuring consistency with `"log2"` and `"log10"`. Retains access to `vegan::decostand(method = "log")` under `method = "log.decostand"` (and alias `"log_decostand"`), updates documentation, and adds unit tests.